### PR TITLE
Add RoundMode

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ echo __token__ | twine upload --repository pypi dist/* --verbose
 All NaNs are the same, with no distinction between signalling or quiet, 
 or between differently encoded NaNs.
 
+

--- a/README.md
+++ b/README.md
@@ -30,4 +30,3 @@ echo __token__ | twine upload --repository pypi dist/* --verbose
 All NaNs are the same, with no distinction between signalling or quiet, 
 or between differently encoded NaNs.
 
-

--- a/docs/requirements-rtd.txt
+++ b/docs/requirements-rtd.txt
@@ -1,1 +1,1 @@
-gfloat
+.[test]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -7,8 +7,8 @@
 project = "GFloat"
 copyright = "2023, Andrew Fitzgibbon"
 author = "Andrew Fitzgibbon"
-release = "0.0.3"
-version = "0.0.3"
+release = "0.0.4"
+version = "0.0.4"
 
 # -- General configuration
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -34,6 +34,8 @@ API
    :members:
 .. autoclass:: gfloat.FloatClass()
    :members:
+.. autoclass:: gfloat.RoundMode()
+   :members:
 .. autoclass:: gfloat.FloatValue()
    :members:
 .. autofunction:: gfloat.decode_float

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,5 +1,4 @@
 
-
 GFloat: Generic floating point formats in Python
 ================================================
 
@@ -30,26 +29,30 @@ handling various current and proposed floating point types:
 API
 ===
 
-.. autofunction:: gfloat.decode_float
-.. autofunction:: gfloat.round_float
-.. autoclass:: gfloat.FormatInfo()
+.. module:: gfloat
+
+.. autofunction:: decode_float
+.. autofunction:: round_float
+.. autoclass:: FormatInfo()
    :members:
-.. autoclass:: gfloat.FloatClass()
+.. autoclass:: FloatClass()
    :members:
-.. autoclass:: gfloat.RoundMode()
+.. autoclass:: RoundMode()
    :members:
-.. autoclass:: gfloat.FloatValue()
+.. autoclass:: FloatValue()
    :members:
 
 Defined Formats
 ===============
 
-.. autodata:: gfloat.formats.format_info_binary32
-.. autodata:: gfloat.formats.format_info_binary16
-.. autodata:: gfloat.formats.format_info_bfloat16
-.. autodata:: gfloat.formats.format_info_ocp_e5m2
-.. autodata:: gfloat.formats.format_info_ocp_e4m3
-.. autofunction:: gfloat.formats.format_info_p3109
+.. module:: gfloat.formats
+
+.. autodata:: format_info_binary32
+.. autodata:: format_info_binary16
+.. autodata:: format_info_bfloat16
+.. autodata:: format_info_ocp_e5m2
+.. autodata:: format_info_ocp_e4m3
+.. autofunction:: format_info_p3109
 
 Index and Search
 ================

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -30,6 +30,8 @@ handling various current and proposed floating point types:
 API
 ===
 
+.. autofunction:: gfloat.decode_float
+.. autofunction:: gfloat.round_float
 .. autoclass:: gfloat.FormatInfo()
    :members:
 .. autoclass:: gfloat.FloatClass()
@@ -38,8 +40,6 @@ API
    :members:
 .. autoclass:: gfloat.FloatValue()
    :members:
-.. autofunction:: gfloat.decode_float
-.. autofunction:: gfloat.round_float
 
 Defined Formats
 ===============

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ package-dir = {"" = "src"}
 
 [project]
 name =  "gfloat"
-version = "0.0.3"
+version = "0.0.4"
 authors = [
     {name = "Andrew Fitzgibbon", email = "awf@fitzgibbon.ie"},
 ]

--- a/src/gfloat/__init__.py
+++ b/src/gfloat/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Graphcore Ltd. All rights reserved.
 
 from .decode import decode_float
-from .round import round_float
+from .round import round_float, RoundMode
 from .types import FormatInfo, FloatClass, FloatValue
 import gfloat.formats
 

--- a/src/gfloat/__init__.py
+++ b/src/gfloat/__init__.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2024 Graphcore Ltd. All rights reserved.
 
+from .types import FormatInfo, FloatClass, FloatValue, RoundMode
 from .decode import decode_float
-from .round import round_float, RoundMode
-from .types import FormatInfo, FloatClass, FloatValue
+from .round import round_float
 import gfloat.formats
 
 # Don't automatically import from .formats.

--- a/src/gfloat/formats.py
+++ b/src/gfloat/formats.py
@@ -12,7 +12,6 @@ format_info_binary32 = FormatInfo(
     has_infs=True,
     num_high_nans=2**23 - 1,
     has_subnormals=True,
-    preferred_rounding=RoundMode.TiesToEven,
 )
 
 #: FormatInfo for IEEE-754 Binary16 format
@@ -25,7 +24,6 @@ format_info_binary16 = FormatInfo(
     has_infs=True,
     num_high_nans=2**10 - 1,
     has_subnormals=True,
-    preferred_rounding=RoundMode.TiesToEven,
 )
 
 #: FormatInfo for Google BFloat16 format
@@ -38,7 +36,6 @@ format_info_bfloat16 = FormatInfo(
     has_infs=True,
     num_high_nans=2**7 - 1,
     has_subnormals=True,
-    preferred_rounding=RoundMode.TiesToEven,
 )
 
 #: FormatInfo for OCP E5M2 format
@@ -51,7 +48,6 @@ format_info_ocp_e5m2 = FormatInfo(
     has_infs=True,
     num_high_nans=2**2 - 1,
     has_subnormals=True,
-    preferred_rounding=RoundMode.OCP_NONSAT,
 )
 
 #: FormatInfo for OCP E4M3 format
@@ -64,7 +60,6 @@ format_info_ocp_e4m3 = FormatInfo(
     has_infs=False,
     num_high_nans=1,
     has_subnormals=True,
-    preferred_rounding=RoundMode.OCP_NONSAT,
 )
 
 
@@ -95,5 +90,4 @@ def format_info_p3109(precision: int) -> FormatInfo:
         has_infs=True,
         num_high_nans=0,
         has_subnormals=True,
-        preferred_rounding=RoundMode.TiesToEven,
     )

--- a/src/gfloat/formats.py
+++ b/src/gfloat/formats.py
@@ -1,6 +1,6 @@
 # Copyright (c) 2024 Graphcore Ltd. All rights reserved.
 
-from gfloat import FormatInfo
+from gfloat import FormatInfo, RoundMode
 
 #: FormatInfo for IEEE-754 Binary32 format
 format_info_binary32 = FormatInfo(
@@ -12,6 +12,7 @@ format_info_binary32 = FormatInfo(
     has_infs=True,
     num_high_nans=2**23 - 1,
     has_subnormals=True,
+    preferred_rounding=RoundMode.TiesToEven,
 )
 
 #: FormatInfo for IEEE-754 Binary16 format
@@ -24,6 +25,7 @@ format_info_binary16 = FormatInfo(
     has_infs=True,
     num_high_nans=2**10 - 1,
     has_subnormals=True,
+    preferred_rounding=RoundMode.TiesToEven,
 )
 
 #: FormatInfo for Google BFloat16 format
@@ -36,6 +38,7 @@ format_info_bfloat16 = FormatInfo(
     has_infs=True,
     num_high_nans=2**7 - 1,
     has_subnormals=True,
+    preferred_rounding=RoundMode.TiesToEven,
 )
 
 #: FormatInfo for OCP E5M2 format
@@ -48,6 +51,7 @@ format_info_ocp_e5m2 = FormatInfo(
     has_infs=True,
     num_high_nans=2**2 - 1,
     has_subnormals=True,
+    preferred_rounding=RoundMode.OCP_NONSAT,
 )
 
 #: FormatInfo for OCP E4M3 format
@@ -60,6 +64,7 @@ format_info_ocp_e4m3 = FormatInfo(
     has_infs=False,
     num_high_nans=1,
     has_subnormals=True,
+    preferred_rounding=RoundMode.OCP_NONSAT,
 )
 
 
@@ -90,4 +95,5 @@ def format_info_p3109(precision: int) -> FormatInfo:
         has_infs=True,
         num_high_nans=0,
         has_subnormals=True,
+        preferred_rounding=RoundMode.TiesToEven,
     )

--- a/src/gfloat/round.py
+++ b/src/gfloat/round.py
@@ -29,11 +29,11 @@ def round_float(fi: FormatInfo, v: float, rnd=RoundMode.TiesToEven, sat=False) -
     :param rnd: Rounding mode to use
     :type rnd: RoundMode
 
-    :param sat: Saturation flag: if True, round overflowed values to |fi|.max
+    :param sat: Saturation flag: if True, round overflowed values to `fi.max`
     :type sat: bool
 
     :raises ValueError: The target format cannot represent the input
-       (e.g. converting a NaN, or an Inf when the target has no Inf or NaN, and ¬|sat|)
+       (e.g. converting a NaN, or an Inf when the target has no Inf or NaN, and `¬sat`)
 
     :return: A float which equals (inc. nan) one of the values in the format
     :rtype: float

--- a/src/gfloat/round.py
+++ b/src/gfloat/round.py
@@ -68,14 +68,18 @@ def round_float(fi: FormatInfo, v: float, rnd=None) -> float:
             elif rnd == RoundMode.TowardNegative:
                 isignificand += 1 if sign else 0
             else:
+                # Round to nearest
                 d = fsignificand - isignificand
                 if d > 0.5:
                     isignificand += 1
                 elif d == 0.5:
-                    if (rnd == RoundMode.TiesToAway) or (
-                        rnd == RoundMode.TiesToEven and _isodd(isignificand)
-                    ):
+                    # Tie
+                    if rnd == RoundMode.TiesToAway:
                         isignificand += 1
+                    else:
+                        # All other modes tie to even
+                        if _isodd(isignificand):
+                            isignificand += 1
 
         result = isignificand * (2.0**expval)
     else:
@@ -89,6 +93,7 @@ def round_float(fi: FormatInfo, v: float, rnd=None) -> float:
 
     # Overflow
     if rnd == RoundMode.OCP_NONSAT:
+        # Check v, not result, as the spec says all values > fi.max should become inf
         if v > fi.max:
             result = np.inf if fi.has_infs else np.nan
     elif rnd == RoundMode.OCP_SAT:

--- a/src/gfloat/round.py
+++ b/src/gfloat/round.py
@@ -17,9 +17,9 @@ def iseven(v: int):
 
 class RoundMode(Enum):
     """
-    Enum for the classification of a FloatValue.
+    Enum for IEEE-754 rounding modes.
 
-    Result r is obtained from input v as follows
+    Result r is obtained from input v depending on rounding mode as follows
     """
 
     TowardZero = 1  #: max{r s.t. |r| <= |v|}

--- a/src/gfloat/round.py
+++ b/src/gfloat/round.py
@@ -92,21 +92,15 @@ def round_float(fi: FormatInfo, v: float, rnd=None) -> float:
             return 0.0
 
     # Overflow
-    if rnd == RoundMode.OCP_NONSAT:
-        # Check v, not result, as the spec says all values > fi.max should become inf
-        if v > fi.max:
-            result = np.inf if fi.has_infs else np.nan
-    elif rnd == RoundMode.OCP_SAT:
-        if v > fi.max:
+    # Compare rounded result to fi.max, so the values between
+    # fi.max and halfup(fi.max) round to fi.max
+    if result > fi.max:
+        if rnd == RoundMode.OCP_SAT:
             result = fi.max
-    else:
-        # Compare rounded result to fi.max, so the values between
-        # fi.max and halfup(fi.max) round to fi.max
-        if result > fi.max:
-            if fi.has_infs:
-                result = np.inf
-            else:
-                result = fi.max
+        elif rnd == RoundMode.OCP_NONSAT:
+            result = np.inf if fi.has_infs else np.nan
+        else:
+            result = np.inf if fi.has_infs else fi.max
 
     # Set sign
     if sign:

--- a/src/gfloat/types.py
+++ b/src/gfloat/types.py
@@ -12,13 +12,11 @@ class RoundMode(Enum):
     Result r is obtained from input v depending on rounding mode as follows
     """
 
-    TowardZero = 1  #: max{r s.t. |r| <= |v|}
-    TowardNegative = 2  #: max{r s.t. r <= v}
-    TowardPositive = 3  #: min{r s.t. r >= v}
+    TowardZero = 1  #: :math:`\max \{ r ~ s.t. ~ |r| \le |v| \}`
+    TowardNegative = 2  #: :math:`\max \{ r ~ s.t. ~ r \le v \}`
+    TowardPositive = 3  #: :math:`\min \{ r ~ s.t. ~ r \ge v \}`
     TiesToEven = 4  #: Round to nearest, ties to even
     TiesToAway = 5  #: Round to nearest, ties away from zero
-    OCP_SAT = 6  #: OCP FP8 Spec Saturating mode
-    OCP_NONSAT = 7  #: OCP FP8 Spec Non-saturating mode
 
 
 @dataclass
@@ -55,9 +53,6 @@ class FormatInfo:
 
     #: Set if format encodes subnormals
     has_subnormals: bool
-
-    #: Format's preferred rounding mode
-    preferred_rounding: RoundMode
 
     #: ## Derived values
 

--- a/src/gfloat/types.py
+++ b/src/gfloat/types.py
@@ -5,6 +5,22 @@ from enum import Enum
 import numpy as np
 
 
+class RoundMode(Enum):
+    """
+    Enum for IEEE-754 rounding modes.
+
+    Result r is obtained from input v depending on rounding mode as follows
+    """
+
+    TowardZero = 1  #: max{r s.t. |r| <= |v|}
+    TowardNegative = 2  #: max{r s.t. r <= v}
+    TowardPositive = 3  #: min{r s.t. r >= v}
+    TiesToEven = 4  #: Round to nearest, ties to even
+    TiesToAway = 5  #: Round to nearest, ties away from zero
+    OCP_SAT = 6  #: OCP FP8 Spec Saturating mode
+    OCP_NONSAT = 7  #: OCP FP8 Spec Non-saturating mode
+
+
 @dataclass
 class FormatInfo:
     """
@@ -39,6 +55,9 @@ class FormatInfo:
 
     #: Set if format encodes subnormals
     has_subnormals: bool
+
+    #: Format's preferred rounding mode
+    preferred_rounding: RoundMode
 
     #: ## Derived values
 

--- a/test/test_round.py
+++ b/test/test_round.py
@@ -40,34 +40,28 @@ def test_round_p3109():
 
 def test_round_e5m2():
     fi = format_info_ocp_e5m2
+
     assert round_float(fi, 1.5258789e-05) == 2**-16
-    assert round_float(fi, 57344) == 57344
-    assert round_float(fi, 57341) == 57344
-    assert round_float(fi, 61439.9) == 57344
-    assert round_float(fi, 61440.0) == np.inf
 
-
-def test_ml_dtype_spot():
-    fi = format_info_ocp_e5m2
-    # Default IEEE-like rounding
+    # Default OCP_NONSAT rounding
     assert round_float(fi, 57344.0) == 57344
-    assert round_float(fi, 57344.1) == 57344
-    assert round_float(fi, 61439.9) == 57344
+    assert round_float(fi, 57344.1) == np.inf
+    assert round_float(fi, 61439.9) == np.inf
     assert round_float(fi, 61440.0) == np.inf
 
-    # OCP rounding
-    rnd = RoundMode.OCP_NONSAT
-    assert round_float(fi, 57344.0, rnd) == 57344
-    assert round_float(fi, 57344.1, rnd) == np.inf
-    assert round_float(fi, 61439.9, rnd) == np.inf
-    assert round_float(fi, 61440.0, rnd) == np.inf
-
-    # OCP rounding
+    # OCP_SAT rounding
     rnd = RoundMode.OCP_SAT
     assert round_float(fi, 57344.0, rnd) == 57344
     assert round_float(fi, 57344.1, rnd) == 57344
     assert round_float(fi, 61439.9, rnd) == 57344
     assert round_float(fi, 61440.0, rnd) == 57344
+
+    # ml_dtypes IEEE-like rounding
+    rnd = RoundMode.TiesToEven
+    assert round_float(fi, 57344.0, rnd) == 57344
+    assert round_float(fi, 57344.1, rnd) == 57344
+    assert round_float(fi, 61439.9, rnd) == 57344
+    assert round_float(fi, 61440.0, rnd) == np.inf
 
 
 p3109_formats = [format_info_p3109(p) for p in range(2, 7)]

--- a/test/test_round.py
+++ b/test/test_round.py
@@ -60,7 +60,7 @@ def test_round_e5m2():
     assert round_float(fi, 61439.9, sat=True) == 57344
     assert round_float(fi, 61440.0, sat=True) == 57344
     assert round_float(fi, np.inf, sat=True) == 57344
-    assert round_float(fi, -np.inf, sat=True) == 57344
+    assert round_float(fi, -np.inf, sat=True) == -57344
     assert np.isnan(round_float(fi, np.nan, sat=True))
 
 

--- a/test/test_round.py
+++ b/test/test_round.py
@@ -45,8 +45,8 @@ def test_round_e5m2():
 
     # Default OCP_NONSAT rounding
     assert round_float(fi, 57344.0) == 57344
-    assert round_float(fi, 57344.1) == np.inf
-    assert round_float(fi, 61439.9) == np.inf
+    assert round_float(fi, 57344.1) == 57344
+    assert round_float(fi, 61439.9) == 57344
     assert round_float(fi, 61440.0) == np.inf
 
     # OCP_SAT rounding

--- a/test/test_round.py
+++ b/test/test_round.py
@@ -83,15 +83,9 @@ def test_round_e4m3():
     assert round_float(fi, 448.1, sat=True) == 448
     assert round_float(fi, 464.0, sat=True) == 448
     assert round_float(fi, 464.01, sat=True) == 448
-    assert round_float(fi, np.inf, sat=True) == fi.max
-    assert round_float(fi, -np.inf, sat=True) == fi.min
+    assert round_float(fi, np.inf, sat=True) == 448
+    assert round_float(fi, -np.inf, sat=True) == -448
     assert np.isnan(round_float(fi, np.nan, sat=True))
-
-    for v in (448, 458, 468, 478):
-        val = round_float(fi, v, RoundMode.TiesToEven)
-
-        mlval = _mlround(v, ml_dtypes.float8_e4m3fn)
-        np.testing.assert_equal(val, mlval)
 
 
 p3109_formats = [format_info_p3109(p) for p in range(2, 7)]


### PR DESCRIPTION
Implements IEEE-754 rounding modes, rather than deferring to python `round`.

Docs preview at https://gfloat--1.org.readthedocs.build/en/1