### PR TITLE
Add MX subformats

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -55,6 +55,9 @@ Defined Formats
 .. autodata:: format_info_ocp_e5m2
 .. autodata:: format_info_ocp_e4m3
 .. autofunction:: format_info_p3109
+.. autodata:: format_info_ocp_e3m2
+.. autodata:: format_info_ocp_e2m3
+.. autodata:: format_info_ocp_e2m1
 
 Index and Search
 ================

--- a/src/gfloat/formats.py
+++ b/src/gfloat/formats.py
@@ -150,6 +150,7 @@ fp16_formats = [
 ]
 
 all_formats = [
+    *tiny_formats,
     *fp8_formats,
     *fp16_formats,
     format_info_binary32,

--- a/src/gfloat/formats.py
+++ b/src/gfloat/formats.py
@@ -62,6 +62,42 @@ format_info_ocp_e4m3 = FormatInfo(
     has_subnormals=True,
 )
 
+#: FormatInfo for OCP MX E2M3 format
+format_info_ocp_e2m3 = FormatInfo(
+    name="ocp_e2m3",
+    k=6,
+    precision=4,
+    emax=2,
+    has_nz=True,
+    has_infs=False,
+    num_high_nans=0,
+    has_subnormals=True,
+)
+
+#: FormatInfo for OCP MX E3M2 format
+format_info_ocp_e3m2 = FormatInfo(
+    name="ocp_e3m2",
+    k=6,
+    precision=3,
+    emax=4,
+    has_nz=True,
+    has_infs=False,
+    num_high_nans=0,
+    has_subnormals=True,
+)
+
+#: FormatInfo for OCP MX E2M1 format
+format_info_ocp_e2m1 = FormatInfo(
+    name="ocp_e2m1",
+    k=4,
+    precision=2,
+    emax=2,
+    has_nz=True,
+    has_infs=False,
+    num_high_nans=0,
+    has_subnormals=True,
+)
+
 
 def format_info_p3109(precision: int) -> FormatInfo:
     """
@@ -94,6 +130,12 @@ def format_info_p3109(precision: int) -> FormatInfo:
 
 
 ## Collections of formats
+tiny_formats = [
+    format_info_ocp_e2m3,
+    format_info_ocp_e3m2,
+    format_info_ocp_e2m1,
+]
+
 p3109_formats = [format_info_p3109(p) for p in range(1, 7)]
 
 fp8_formats = [

--- a/src/gfloat/types.py
+++ b/src/gfloat/types.py
@@ -317,7 +317,7 @@ class FormatInfo:
     def smallest_normal(self) -> float:
         """
         The smallest positive floating point number with 1 as leading bit in
-        the mantissa following IEEE-754 (see Notes).
+        the significand following IEEE-754.
         """
         assert self.has_subnormals, "not implemented"
         return 2 ** (1 - self.expBias)
@@ -326,7 +326,7 @@ class FormatInfo:
     def smallest_subnormal(self) -> float:
         """
         The smallest positive floating point number with 0 as leading bit in
-        the mantissa following IEEE-754.
+        the significand following IEEE-754.
         """
         assert self.has_subnormals, "not implemented"
         return 2 ** -(self.expBias + self.tSignificandBits - 1)

--- a/src/gfloat/types.py
+++ b/src/gfloat/types.py
@@ -313,12 +313,14 @@ class FormatInfo:
     #     An alias for `smallest_normal`, kept for backwards compatibility.
     #     """
 
-    # @property
-    # def smallest_normal(self) -> float:
-    #     """
-    #     The smallest positive floating point number with 1 as leading bit in
-    #     the mantissa following IEEE-754 (see Notes).
-    #     """
+    @property
+    def smallest_normal(self) -> float:
+        """
+        The smallest positive floating point number with 1 as leading bit in
+        the mantissa following IEEE-754 (see Notes).
+        """
+        assert self.has_subnormals, "not implemented"
+        return 2 ** (1 - self.expBias)
 
     @property
     def smallest_subnormal(self) -> float:

--- a/test/test_decode.py
+++ b/test/test_decode.py
@@ -7,6 +7,10 @@ from gfloat import decode_float, FloatClass
 from gfloat.formats import *
 
 
+def _isnegzero(x):
+    return (x == 0) and (np.signbit(x) == 1)
+
+
 def test_spot_check_ocp_e5m2():
     fi = format_info_ocp_e5m2
     dec = lambda ival: decode_float(fi, ival).fval
@@ -82,6 +86,54 @@ def test_spot_check_bfloat16():
     assert np.isinf(dec(0x7F80))
     assert np.isnan(dec(0x7F81))
     assert np.isnan(dec(0x7FFF))
+
+
+def test_spot_check_ocp_e2m3():
+    # Test against Table 4 in "OCP Microscaling Formats (MX) v1.0 Spec"
+    fi = format_info_ocp_e2m3
+    dec = lambda ival: decode_float(fi, ival).fval
+    fclass = lambda ival: decode_float(fi, ival).fclass
+    assert fi.max == 7.5
+    assert fi.smallest_subnormal == 0.125
+    assert fi.smallest_normal == 1.0
+
+    assert dec(0b000000) == 0
+    assert dec(0b011111) == 7.5
+    assert _isnegzero(dec(0b100000))
+
+
+def test_spot_check_ocp_e3m2():
+    # Test against Table 4 in "OCP Microscaling Formats (MX) v1.0 Spec"
+    fi = format_info_ocp_e3m2
+    dec = lambda ival: decode_float(fi, ival).fval
+    fclass = lambda ival: decode_float(fi, ival).fclass
+    assert fi.max == 28.0
+    assert fi.smallest_subnormal == 0.0625
+    assert fi.smallest_normal == 0.25
+
+    assert dec(0b000000) == 0
+    assert dec(0b011111) == 28.0
+    assert _isnegzero(dec(0b100000))
+
+
+def test_spot_check_ocp_e2m1():
+    # Test against Table 5 in "OCP Microscaling Formats (MX) v1.0 Spec"
+    fi = format_info_ocp_e2m1
+    dec = lambda ival: decode_float(fi, ival).fval
+    fclass = lambda ival: decode_float(fi, ival).fclass
+    assert fi.max == 6.0
+    assert fi.smallest_subnormal == 0.5
+    assert fi.smallest_normal == 1.0
+
+    assert dec(0b0000) == 0
+    assert dec(0b0001) == 0.5
+    assert dec(0b0010) == 1.0
+    assert dec(0b0011) == 1.5
+    assert dec(0b0100) == 2.0
+    assert dec(0b0101) == 3.0
+    assert dec(0b0110) == 4.0
+    assert dec(0b0111) == 6.0
+    assert _isnegzero(dec(0b1000))
 
 
 @pytest.mark.parametrize("fi", p3109_formats, ids=str)


### PR DESCRIPTION
Adds FP6 and FP4 formats from the [OCP Microscaling Formats (MX) Specification](https://www.opencompute.org/documents/ocp-microscaling-formats-mx-v1-0-spec-final-pdf)

Docs preview at https://gfloat--4.org.readthedocs.build/en/4/

Also implements `FormatInfo.smallest_normal`, but it didn't feel worth it to pull that out into a separate PR.
