### PR TITLE
Add block formats

### DIFF
--- a/docs/source/01-decode.ipynb
+++ b/docs/source/01-decode.ipynb
@@ -45,7 +45,7 @@
     {
      "data": {
       "text/plain": [
-       "FormatInfo(name='ocp_e5m2', k=8, precision=3, emax=15, has_nz=True, has_infs=True, num_high_nans=3, has_subnormals=True)"
+       "FormatInfo(name='ocp_e5m2', k=8, precision=3, emax=15, has_nz=True, has_infs=True, num_high_nans=3, has_subnormals=True, is_signed=True, is_twos_complement=False)"
       ]
      },
      "execution_count": 2,

--- a/docs/source/01-decode.ipynb
+++ b/docs/source/01-decode.ipynb
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -39,7 +39,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -48,7 +48,7 @@
        "FormatInfo(name='ocp_e5m2', k=8, precision=3, emax=15, has_nz=True, has_infs=True, num_high_nans=3, has_subnormals=True, is_signed=True, is_twos_complement=False)"
       ]
      },
-     "execution_count": 2,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -258,7 +258,7 @@
        "[256 rows x 7 columns]"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -281,22 +281,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 19,
    "metadata": {},
    "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Exponent bias           7                    15\n",
-      "emax                    8                    15\n",
-      "Infinities              0                    2\n",
-      "Number of NaNs          2                    6\n",
-      "Number of zeros         2                    2\n",
-      "Max normal number       448.0                57344.0\n",
-      "Min normal number       0.015625             6.103515625e-05\n",
-      "Min subnormal number    0.001953125          1.52587890625e-05\n",
-      "Dynamic range (binades) 18                   32\n"
+      "Exponent bias           7                    15                    16\n",
+      "emax                    8                    15                    15\n",
+      "Infinities              0                    2                     2\n",
+      "Number of NaNs          2                    6                     1\n",
+      "Number of zeros         2                    2                     1\n",
+      "Max normal number       448.0                57344.0               49152.0\n",
+      "Min normal number       0.015625             6.103515625e-05       3.0517578125e-05\n",
+      "Min subnormal number    0.001953125          1.52587890625e-05     7.62939453125e-06\n",
+      "Dynamic range (binades) 18                   32                    33\n"
      ]
     }
    ],
@@ -306,17 +306,17 @@
     "\n",
     "\n",
     "for prop, probe in (\n",
+    "    (\"Max exponent (emax)    \", lambda fi: fi.emax),\n",
     "    (\"Exponent bias          \", lambda fi: fi.expBias),\n",
-    "    (\"emax                   \", lambda fi: fi.emax),\n",
-    "    (\"Infinities             \", lambda fi: 2 * fi.has_infs),\n",
+    "    (\"Infinities             \", lambda fi: 2 * int(fi.has_infs)),\n",
     "    (\"Number of NaNs         \", lambda fi: fi.num_nans),\n",
-    "    (\"Number of zeros        \", lambda fi: 1 + fi.has_nz),\n",
+    "    (\"Number of zeros        \", lambda fi: int(fi.has_zero) + int(fi.has_nz)),\n",
     "    (\"Max normal number      \", lambda fi: fi.max),\n",
     "    (\"Min normal number      \", lambda fi: fi.smallest_normal),\n",
     "    (\"Min subnormal number   \", lambda fi: fi.smallest_subnormal),\n",
     "    (\"Dynamic range (binades)\", lambda x: round(compute_dynamic_range(x))),\n",
     "):\n",
-    "    print(f\"{prop} {probe(format_info_ocp_e4m3):<20} {probe(format_info_ocp_e5m2)}\")"
+    "    print(f\"{prop} {probe(format_info_ocp_e4m3):<20} {probe(format_info_ocp_e5m2):<20}  {probe(format_info_p3109(3))}\")"
    ]
   },
   {
@@ -331,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 17,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,7 +350,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 18,
    "metadata": {},
    "outputs": [
     {

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -7,6 +7,10 @@ API
 .. autofunction:: round_float
 .. autofunction:: encode_float
 
+.. autofunction:: decode_block
+.. autofunction:: encode_block
+
+
 .. autoclass:: FormatInfo()
    :members:
 .. autoclass:: FloatClass()

--- a/docs/source/formats.rst
+++ b/docs/source/formats.rst
@@ -13,3 +13,4 @@ Defined Formats
 .. autodata:: format_info_ocp_e2m3
 .. autodata:: format_info_ocp_e2m1
 .. autodata:: format_info_ocp_e8m0
+.. autodata:: format_info_ocp_int8

--- a/docs/source/formats.rst
+++ b/docs/source/formats.rst
@@ -3,10 +3,20 @@ Defined Formats
 
 .. module:: gfloat.formats
 
+IEEE 754 Formats
+----------------
+
 .. autodata:: format_info_binary32
 .. autodata:: format_info_binary16
+
+BFloat16
+----------------
+
 .. autodata:: format_info_bfloat16
-.. autofunction:: format_info_p3109
+
+Open Compute Platform (OCP) Formats
+-----------------------------------
+
 .. autodata:: format_info_ocp_e5m2
 .. autodata:: format_info_ocp_e4m3
 .. autodata:: format_info_ocp_e3m2
@@ -14,3 +24,8 @@ Defined Formats
 .. autodata:: format_info_ocp_e2m1
 .. autodata:: format_info_ocp_e8m0
 .. autodata:: format_info_ocp_int8
+
+IEEE WG P3109 Formats
+---------------------
+
+.. autofunction:: format_info_p3109

--- a/docs/source/formats.rst
+++ b/docs/source/formats.rst
@@ -6,9 +6,10 @@ Defined Formats
 .. autodata:: format_info_binary32
 .. autodata:: format_info_binary16
 .. autodata:: format_info_bfloat16
+.. autofunction:: format_info_p3109
 .. autodata:: format_info_ocp_e5m2
 .. autodata:: format_info_ocp_e4m3
-.. autofunction:: format_info_p3109
 .. autodata:: format_info_ocp_e3m2
 .. autodata:: format_info_ocp_e2m3
 .. autodata:: format_info_ocp_e2m1
+.. autodata:: format_info_ocp_e8m0

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,7 +1,11 @@
+.. note::
+
+  Check the version number of this documentation against the `gfloat` version
+  you are using.  "Latest" refers to the head on https://github.com/graphcore-research/gfloat,
+  while pypi versions installed using `pip install` will have corresponding `vX.Y.Z` tags.
 
 GFloat: Generic floating point formats in Python
 ================================================
-
 
 GFloat is designed to allow experimentation with a variety of floating-point
 formats in Python.  Formats are parameterized by the primary IEEE-754 parameters
@@ -12,16 +16,16 @@ of:
   * Maximum exponent (emax)
 
 with additional fields defining the encoding of infinities, Not-a-number (NaN) values,
-and negative zero, among others.
+and negative zero, among others (see :class:`gfloat.FormatInfo`.)
 
 This allows an implementation of generic floating point encode/decode logic,
 handling various current and proposed floating point types:
 
  - `IEEE 754 <https://en.wikipedia.org/wiki/IEEE_754>`_: Binary16, Binary32
- - `OCP Float8 <https://www.opencompute.org/documents/ocp-8-bit-floating-point-specification-ofp8-revision-1-0-2023-06-20-pdf>`_: E5M2, E4M3
+ - `OCP Float8 <https://www.opencompute.org/documents/ocp-8-bit-floating-point-specification-ofp8-revision-1-0-2023-06-20-pdf>`_: E5M2, E4M3, and MX formats
  - `IEEE WG P3109 <https://github.com/awf/P3109-Public/blob/main/Shared%20Reports/P3109%20WG%20Interim%20report.pdf>`_: P{p} for p in 1..7
 
-The library strongly favours readability and extensibility over speed - for fast
+The library favours readability and extensibility over speed - for fast
 implementations of these datatypes see, for example,
 `ml_dtypes <https://github.com/jax-ml/ml_dtypes>`_,
 `bitstring <https://github.com/scott-griffiths/bitstring>`_,

--- a/src/gfloat/__init__.py
+++ b/src/gfloat/__init__.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2024 Graphcore Ltd. All rights reserved.
 
 from .decode import decode_float
-from .round import encode_float, round_float
-from .types import FloatClass, FloatValue, FormatInfo, RoundMode
+from .round import round_float, encode_float
+from .block import BlockFormatInfo, encode_block, decode_block
 
 # Don't automatically import from .formats.
 # If the user wants them in their namespace, they can explicitly import

--- a/src/gfloat/__init__.py
+++ b/src/gfloat/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (c) 2024 Graphcore Ltd. All rights reserved.
 
+from .types import FloatClass, FormatInfo, RoundMode
 from .decode import decode_float
 from .round import round_float, encode_float
 from .block import BlockFormatInfo, encode_block, decode_block

--- a/src/gfloat/__init__.py
+++ b/src/gfloat/__init__.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2024 Graphcore Ltd. All rights reserved.
 
-from .types import FloatClass, FormatInfo, RoundMode
+from .block import BlockFormatInfo, decode_block, encode_block
 from .decode import decode_float
-from .round import round_float, encode_float
-from .block import BlockFormatInfo, encode_block, decode_block
+from .round import encode_float, round_float
+from .types import FloatClass, FloatValue, FormatInfo, RoundMode
 
 # Don't automatically import from .formats.
 # If the user wants them in their namespace, they can explicitly import

--- a/src/gfloat/block.py
+++ b/src/gfloat/block.py
@@ -51,9 +51,21 @@ class BlockFormatInfo:
 
 def decode_block(fi: BlockFormatInfo, block: Iterable[int]) -> Iterable[float]:
     """
-    Decode a `param:block` of integer codepoints in Block Format `param:fi`
+    Decode a :paramref:`block` of integer codepoints in Block Format :paramref:`fi`
 
-    The scale is assumed to be at the front of the block
+    The scale is encoded in the first value of :paramref:`block`,
+    with the remaining values encoding the block elements.
+
+    The size of the iterable is not checked against the format descriptor.
+
+    :param fi: Describes the block format
+    :type fi: BlockFormatInfo
+
+    :param block: Input block
+    :type block: Iterable[int]
+
+    :return: A sequence of floats representing the encoded values.
+    :rtype: Iterable[float]
     """
     it = iter(block)
 
@@ -71,12 +83,28 @@ def encode_block(
     fi: BlockFormatInfo, scale: float, vals: Iterable[float]
 ) -> Iterable[int]:
     """
-    Encode a `param:block` of bytes into Block Format `param:fi`
+    Encode a :paramref:`block` of bytes into block Format descibed by :paramref:`fi`
 
-    The desired scale is explicitly passed, and is converted to 1/(1/scale)
+    The :paramref:`scale` is explicitly passed, and is converted to `1/(1/scale)`
     before rounding to the target format.
+
     It is checked for overflow in the target format,
     and will raise an exception if it does.
+
+    :param fi: Describes the target block format
+    :type fi: BlockFormatInfo
+
+    :param scale: Scale to be recorded in the block
+    :type scale: float
+
+    :param vals: Input block
+    :type vals: Iterable[int]
+
+    :return: A sequence of ints representing the encoded values.
+    :rtype: Iterable[int]
+
+    :raises ValueError: The scale overflows the target scale encoding format.
+
     """
     recip_scale = 1 / scale
     scale = 1 / recip_scale

--- a/src/gfloat/block.py
+++ b/src/gfloat/block.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2024 Graphcore Ltd. All rights reserved.
+
+# Block floating point formats
+# https://en.wikipedia.org/wiki/Block_floating_point
+
+from dataclasses import dataclass
+from typing import Iterable, Iterator
+
+from .decode import decode_float
+from .round import encode_float, round_float
+from .types import FloatValue, FormatInfo
+
+
+@dataclass
+class BlockFormatInfo:
+
+    #: Short name for the format, e.g. BlockFP8
+    name: str
+
+    #: Element data type
+    etype: FormatInfo
+
+    #: Scaling block size
+    k: int
+
+    #: Scale datatype
+    stype: FormatInfo
+
+    #: ## Derived values
+
+    @property
+    def element_bits(self) -> int:
+        """The number of bits in each element, d"""
+        return self.etype.k
+
+    @property
+    def scale_bits(self) -> int:
+        """The number of bits in the scale, w"""
+        return self.stype.k
+
+    @property
+    def block_size_bytes(self) -> int:
+        """The number of bytes in a block"""
+        bits = self.element_bits * self.k + self.scale_bits
+        assert bits % 8 == 0
+        return bits // 8
+
+    def __str__(self):
+        return f"{self.name}"
+
+
+def decode_block(fi: BlockFormatInfo, block: Iterable[int]) -> Iterable[float]:
+    """
+    Decode a `param:block` of integer codepoints in Block Format `param:fi`
+
+    The scale is assumed to be at the front of the block
+    """
+    it = iter(block)
+
+    scale_encoding = next(it)
+    scale = decode_float(fi.stype, scale_encoding).fval
+
+    for val_encoding in it:
+        val = scale * decode_float(fi.etype, val_encoding).fval
+        yield val
+
+    # TODO: Assert length of block was k+1?  Messy unless block is len()able
+
+
+def encode_block(
+    fi: BlockFormatInfo, scale: float, vals: Iterable[float]
+) -> Iterable[int]:
+    """
+    Encode a `param:block` of bytes into Block Format `param:fi`
+
+    The desired scale is explicitly passed, and is converted to 1/(1/scale)
+    before rounding to the target format.
+    It is checked for overflow in the target format,
+    and will raise an exception if it does.
+    """
+    recip_scale = 1 / scale
+    scale = 1 / recip_scale
+
+    if scale > fi.stype.max:
+        raise ValueError(f"Scaled {scale} too large for {fi.stype}")
+
+    enc = lambda ty, x: encode_float(ty, round_float(ty, x))
+
+    yield enc(fi.stype, scale)
+
+    for val in vals:
+        yield enc(fi.etype, recip_scale * val)

--- a/src/gfloat/decode.py
+++ b/src/gfloat/decode.py
@@ -44,8 +44,7 @@ def decode_float(fi: FormatInfo, i: int) -> FloatValue:
 
     expBias = fi.expBias
 
-    # t == 0 means zero mantissa bits, assume = 1 (otherwise all values are zero)
-    iszero = exp == 0 and significand == 0 and t > 0
+    iszero = exp == 0 and significand == 0 and fi.has_zero
     issubnormal = fi.has_subnormals and (exp == 0) and (significand != 0)
     isnormal = not iszero and not issubnormal
     if iszero or issubnormal:

--- a/src/gfloat/decode.py
+++ b/src/gfloat/decode.py
@@ -64,7 +64,7 @@ def decode_float(fi: FormatInfo, i: int) -> FloatValue:
 
     fval = val
     # All-bits-special exponent (ABSE)
-    if exp == 2**w - 1:
+    if w > 0 and exp == 2**w - 1:
         min_i_with_nan = 2 ** (p - 1) - fi.num_high_nans
         if significand >= min_i_with_nan:
             fval = np.nan
@@ -72,7 +72,7 @@ def decode_float(fi: FormatInfo, i: int) -> FloatValue:
             fval = signed_infinity
 
     # Negative zero or NaN
-    if iszero and i == signmask:
+    if iszero and i == signmask and not fi.is_twos_complement:
         if fi.has_nz:
             fval = -0.0
         else:

--- a/src/gfloat/decode.py
+++ b/src/gfloat/decode.py
@@ -23,22 +23,29 @@ def decode_float(fi: FormatInfo, i: int) -> FloatValue:
     """
     k = fi.k
     p = fi.precision
-    t = p - 1  # trailing significand field width
-    w = k - p
+    t = p - 1  # Trailing significand field width
+    num_signbits = 1 if fi.is_signed else 0
+    w = k - t - num_signbits  # Exponent field width
 
     if i < 0 or i >= 2**k:
         raise ValueError(f"Code point {i} not in range [0, 2**{k})")
 
-    signmask = 1 << (k - 1)
-    signbit = 1 if i & signmask else 0
-    sign = -1 if signbit else 1
+    if fi.is_signed:
+        signmask = 1 << (k - 1)
+        signbit = 1 if i & signmask else 0
+        sign = -1 if signbit else 1
+    else:
+        signmask = None
+        signbit = None
+        sign = 1
 
-    exp = (i & (signmask - 1)) >> t
+    exp = (i >> t) & ((1 << w) - 1)
     significand = i & ((1 << t) - 1)
 
     expBias = fi.expBias
 
-    iszero = exp == 0 and significand == 0
+    # t == 0 means zero mantissa bits, assume = 1 (otherwise all values are zero)
+    iszero = exp == 0 and significand == 0 and t > 0
     issubnormal = fi.has_subnormals and (exp == 0) and (significand != 0)
     isnormal = not iszero and not issubnormal
     if iszero or issubnormal:
@@ -64,7 +71,7 @@ def decode_float(fi: FormatInfo, i: int) -> FloatValue:
             fval = signed_infinity
 
     # Negative zero or NaN
-    if i == signmask:
+    if iszero and i == signmask:
         if fi.has_nz:
             fval = -0.0
         else:

--- a/src/gfloat/decode.py
+++ b/src/gfloat/decode.py
@@ -36,11 +36,13 @@ def decode_float(fi: FormatInfo, i: int) -> FloatValue:
         sign = -1 if signbit else 1
     else:
         signmask = None
-        signbit = None
+        signbit = 0
         sign = 1
 
     exp = (i >> t) & ((1 << w) - 1)
     significand = i & ((1 << t) - 1)
+    if fi.is_twos_complement and signbit:
+        significand = (1 << t) - significand
 
     expBias = fi.expBias
 

--- a/src/gfloat/formats.py
+++ b/src/gfloat/formats.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2024 Graphcore Ltd. All rights reserved.
 
-from gfloat import FormatInfo, RoundMode
+from .types import FormatInfo
+from .block import BlockFormatInfo
 
 #: FormatInfo for IEEE-754 Binary32 format
 format_info_binary32 = FormatInfo(
@@ -177,4 +178,40 @@ all_formats = [
     *fp8_formats,
     *fp16_formats,
     format_info_binary32,
+]
+
+# ------
+# Block formats
+
+format_info_mxfp8_e5m2 = BlockFormatInfo(
+    "ocp_mxfp8_e5m2", format_info_ocp_e5m2, 32, format_info_ocp_e8m0
+)
+
+format_info_mxfp8_e4m3 = BlockFormatInfo(
+    "ocp_mxfp8_e4m3", format_info_ocp_e4m3, 32, format_info_ocp_e8m0
+)
+
+format_info_mxfp6_e3m2 = BlockFormatInfo(
+    "format_info_mxfp6_e3m2", format_info_ocp_e3m2, 32, format_info_ocp_e8m0
+)
+
+format_info_mxfp6_e2m3 = BlockFormatInfo(
+    "format_info_mxfp6_e2m3", format_info_ocp_e2m3, 32, format_info_ocp_e8m0
+)
+
+format_info_mxfp4_e2m1 = BlockFormatInfo(
+    "format_info_mxfp4_e2m1", format_info_ocp_e2m1, 32, format_info_ocp_e8m0
+)
+
+format_info_mxfp4_e2m1 = BlockFormatInfo(
+    "format_info_mxfp4_e2m1", format_info_ocp_e2m1, 32, format_info_ocp_e8m0
+)
+
+all_block_formats = [
+    format_info_mxfp8_e5m2,
+    format_info_mxfp8_e4m3,
+    format_info_mxfp6_e3m2,
+    format_info_mxfp6_e2m3,
+    format_info_mxfp4_e2m1,
+    format_info_mxfp4_e2m1,
 ]

--- a/src/gfloat/formats.py
+++ b/src/gfloat/formats.py
@@ -12,6 +12,7 @@ format_info_binary32 = FormatInfo(
     has_infs=True,
     num_high_nans=2**23 - 1,
     has_subnormals=True,
+    is_signed=True,
 )
 
 #: FormatInfo for IEEE-754 Binary16 format
@@ -24,6 +25,7 @@ format_info_binary16 = FormatInfo(
     has_infs=True,
     num_high_nans=2**10 - 1,
     has_subnormals=True,
+    is_signed=True,
 )
 
 #: FormatInfo for Google BFloat16 format
@@ -36,6 +38,7 @@ format_info_bfloat16 = FormatInfo(
     has_infs=True,
     num_high_nans=2**7 - 1,
     has_subnormals=True,
+    is_signed=True,
 )
 
 #: FormatInfo for OCP E5M2 format
@@ -48,6 +51,7 @@ format_info_ocp_e5m2 = FormatInfo(
     has_infs=True,
     num_high_nans=2**2 - 1,
     has_subnormals=True,
+    is_signed=True,
 )
 
 #: FormatInfo for OCP E4M3 format
@@ -60,6 +64,7 @@ format_info_ocp_e4m3 = FormatInfo(
     has_infs=False,
     num_high_nans=1,
     has_subnormals=True,
+    is_signed=True,
 )
 
 #: FormatInfo for OCP MX E2M3 format
@@ -72,6 +77,7 @@ format_info_ocp_e2m3 = FormatInfo(
     has_infs=False,
     num_high_nans=0,
     has_subnormals=True,
+    is_signed=True,
 )
 
 #: FormatInfo for OCP MX E3M2 format
@@ -84,6 +90,7 @@ format_info_ocp_e3m2 = FormatInfo(
     has_infs=False,
     num_high_nans=0,
     has_subnormals=True,
+    is_signed=True,
 )
 
 #: FormatInfo for OCP MX E2M1 format
@@ -96,6 +103,20 @@ format_info_ocp_e2m1 = FormatInfo(
     has_infs=False,
     num_high_nans=0,
     has_subnormals=True,
+    is_signed=True,
+)
+
+#: FormatInfo for OCP MX E8M0 format
+format_info_ocp_e8m0 = FormatInfo(
+    name="ocp_e8m0",
+    k=8,
+    precision=1,
+    emax=127,
+    has_nz=False,
+    has_infs=False,
+    num_high_nans=1,
+    has_subnormals=False,
+    is_signed=False,
 )
 
 
@@ -126,6 +147,7 @@ def format_info_p3109(precision: int) -> FormatInfo:
         has_infs=True,
         num_high_nans=0,
         has_subnormals=True,
+        is_signed=True,
     )
 
 
@@ -150,6 +172,7 @@ fp16_formats = [
 ]
 
 all_formats = [
+    format_info_ocp_e8m0,
     *tiny_formats,
     *fp8_formats,
     *fp16_formats,

--- a/src/gfloat/formats.py
+++ b/src/gfloat/formats.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2024 Graphcore Ltd. All rights reserved.
 
-from .types import FormatInfo
 from .block import BlockFormatInfo
+from .types import FormatInfo
 
 #: FormatInfo for IEEE-754 Binary32 format
 format_info_binary32 = FormatInfo(

--- a/src/gfloat/formats.py
+++ b/src/gfloat/formats.py
@@ -14,6 +14,7 @@ format_info_binary32 = FormatInfo(
     num_high_nans=2**23 - 1,
     has_subnormals=True,
     is_signed=True,
+    is_twos_complement=False,
 )
 
 #: FormatInfo for IEEE-754 Binary16 format
@@ -27,6 +28,7 @@ format_info_binary16 = FormatInfo(
     num_high_nans=2**10 - 1,
     has_subnormals=True,
     is_signed=True,
+    is_twos_complement=False,
 )
 
 #: FormatInfo for Google BFloat16 format
@@ -40,6 +42,7 @@ format_info_bfloat16 = FormatInfo(
     num_high_nans=2**7 - 1,
     has_subnormals=True,
     is_signed=True,
+    is_twos_complement=False,
 )
 
 #: FormatInfo for OCP E5M2 format
@@ -53,6 +56,7 @@ format_info_ocp_e5m2 = FormatInfo(
     num_high_nans=2**2 - 1,
     has_subnormals=True,
     is_signed=True,
+    is_twos_complement=False,
 )
 
 #: FormatInfo for OCP E4M3 format
@@ -66,6 +70,7 @@ format_info_ocp_e4m3 = FormatInfo(
     num_high_nans=1,
     has_subnormals=True,
     is_signed=True,
+    is_twos_complement=False,
 )
 
 #: FormatInfo for OCP MX E2M3 format
@@ -79,6 +84,7 @@ format_info_ocp_e2m3 = FormatInfo(
     num_high_nans=0,
     has_subnormals=True,
     is_signed=True,
+    is_twos_complement=False,
 )
 
 #: FormatInfo for OCP MX E3M2 format
@@ -92,6 +98,7 @@ format_info_ocp_e3m2 = FormatInfo(
     num_high_nans=0,
     has_subnormals=True,
     is_signed=True,
+    is_twos_complement=False,
 )
 
 #: FormatInfo for OCP MX E2M1 format
@@ -105,6 +112,7 @@ format_info_ocp_e2m1 = FormatInfo(
     num_high_nans=0,
     has_subnormals=True,
     is_signed=True,
+    is_twos_complement=False,
 )
 
 #: FormatInfo for OCP MX E8M0 format
@@ -118,6 +126,21 @@ format_info_ocp_e8m0 = FormatInfo(
     num_high_nans=1,
     has_subnormals=False,
     is_signed=False,
+    is_twos_complement=False,
+)
+
+#: FormatInfo for OCP MX INT8 format
+format_info_ocp_int8 = FormatInfo(
+    name="ocp_int8",
+    k=8,
+    precision=8,
+    emax=0,
+    has_nz=False,
+    has_infs=False,
+    num_high_nans=0,
+    has_subnormals=True,
+    is_signed=True,
+    is_twos_complement=True,
 )
 
 
@@ -149,6 +172,7 @@ def format_info_p3109(precision: int) -> FormatInfo:
         num_high_nans=0,
         has_subnormals=True,
         is_signed=True,
+        is_twos_complement=False,
     )
 
 
@@ -174,6 +198,7 @@ fp16_formats = [
 
 all_formats = [
     format_info_ocp_e8m0,
+    format_info_ocp_int8,
     *tiny_formats,
     *fp8_formats,
     *fp16_formats,

--- a/src/gfloat/round.py
+++ b/src/gfloat/round.py
@@ -218,10 +218,11 @@ def encode_float(fi: FormatInfo, v: float) -> int:
     assert isig < 2**t
     assert biased_exp < 2**fi.expBits
 
-    # Handle two's complement # TODO spelling of twos?
+    # Handle two's complement encoding
     if fi.is_twos_complement and sign:
         isig = (1 << t) - isig
 
+    # Pack values into a single integer
     ival = (sign << (k - 1)) | (biased_exp << t) | (isig << 0)
 
     return ival

--- a/src/gfloat/round.py
+++ b/src/gfloat/round.py
@@ -125,7 +125,7 @@ def round_float(fi: FormatInfo, v: float, rnd=RoundMode.TiesToEven, sat=False) -
             return 0.0
 
     # Overflow
-    if result > fi.max:
+    if result > (-fi.min if sign else fi.max):
         if sat:
             result = fi.max
         else:
@@ -216,7 +216,7 @@ def encode_float(fi: FormatInfo, v: float) -> int:
 
     # Nonzero
     assert isig < 2**t
-    assert biased_exp < 2**fi.expBits
+    assert biased_exp < 2**fi.expBits or fi.is_twos_complement
 
     # Handle two's complement encoding
     if fi.is_twos_complement and sign:

--- a/src/gfloat/round.py
+++ b/src/gfloat/round.py
@@ -218,6 +218,10 @@ def encode_float(fi: FormatInfo, v: float) -> int:
     assert isig < 2**t
     assert biased_exp < 2**fi.expBits
 
+    # Handle two's complement # TODO spelling of twos?
+    if fi.is_twos_complement and sign:
+        isig = (1 << t) - isig
+
     ival = (sign << (k - 1)) | (biased_exp << t) | (isig << 0)
 
     return ival

--- a/src/gfloat/types.py
+++ b/src/gfloat/types.py
@@ -218,7 +218,10 @@ class FormatInfo:
         """
         The number of code points which decode to NaN
         """
-        return (0 if self.has_nz else 1) + 2 * self.num_high_nans
+        if not self.is_signed:
+            return self.num_high_nans
+        else:
+            return (0 if self.has_nz else 1) + 2 * self.num_high_nans
 
     @property
     def code_of_nan(self) -> int:
@@ -351,8 +354,10 @@ class FormatInfo:
         """
         if self.has_subnormals:
             return 2 ** (1 - self.expBias)
-        else:
+        elif self.has_zero:
             return 2**-self.expBias + 2 ** (-self.expBias - self.tSignificandBits)
+        else:
+            return 2**-self.expBias
 
     @property
     def smallest_subnormal(self) -> float:

--- a/src/gfloat/types.py
+++ b/src/gfloat/types.py
@@ -87,6 +87,9 @@ class FormatInfo:
     #: Set if format encodes subnormals
     has_subnormals: bool
 
+    #: Set if the format has a sign bit
+    is_signed: bool
+
     #: ## Derived values
 
     @property
@@ -97,7 +100,7 @@ class FormatInfo:
     @property
     def expBits(self):
         """The number of exponent bits, w"""
-        return self.k - self.precision
+        return self.k - self.precision + (0 if self.is_signed else 1)
 
     @property
     def expBias(self):

--- a/src/gfloat/types.py
+++ b/src/gfloat/types.py
@@ -90,7 +90,7 @@ class FormatInfo:
     #: Set if the format has a sign bit
     is_signed: bool
 
-    #: Set if the format encodes its significand as two's complement
+    #: Set if the format uses two's complement encoding for the significand
     is_twos_complement: bool
 
     #: ## Derived values

--- a/test/test_block.py
+++ b/test/test_block.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2024 Graphcore Ltd. All rights reserved.
+
+import numpy as np
+import pytest
+
+from gfloat import decode_block, encode_block
+from gfloat.formats import *
+
+
+@pytest.mark.parametrize("fi", all_block_formats, ids=str)
+def test_blocks(fi):
+
+    vals = np.linspace(-37.0, 42.0, 32)
+
+    scale = 8.0
+    block = list(encode_block(fi, scale, vals))
+    decoded_vals = list(decode_block(fi, block))
+
+    atol = 2 * scale * fi.etype.eps
+    np.testing.assert_allclose(decoded_vals, vals, atol=atol)

--- a/test/test_decode.py
+++ b/test/test_decode.py
@@ -165,6 +165,23 @@ def test_spot_check_ocp_e8m0():
     assert fclass(0x00) == FloatClass.NORMAL
 
 
+def test_spot_check_ocp_int8():
+    # Test against Table TODO in "OCP Microscaling Formats (MX) v1.0 Spec"
+    fi = format_info_ocp_int8
+    dec = lambda ival: decode_float(fi, ival).fval
+    fclass = lambda ival: decode_float(fi, ival).fclass
+    assert fi.max == 1.0 + 63.0 / 64
+    assert fi.smallest == 2.0**-6
+    assert not fi.has_infs
+    assert fi.num_nans == 1
+
+    assert dec(0x00) == 0.0
+    assert dec(0x01) == fi.smallest
+    assert dec(0x7F) == fi.max
+    assert dec(0x81) == fi.min
+    assert dec(0xFF) == -fi.smallest
+
+
 @pytest.mark.parametrize("fi", p3109_formats, ids=str)
 def test_specials(fi):
     assert fi.code_of_nan == 0x80

--- a/test/test_decode.py
+++ b/test/test_decode.py
@@ -31,7 +31,7 @@ def test_spot_check_ocp_e5m2():
 def test_spot_check_ocp_e4m3():
     fi = format_info_ocp_e4m3
     dec = lambda ival: decode_float(fi, ival).fval
-    fclass = lambda ival: decode_float(fi, ival).fclass
+
     assert dec(0x40) == 2.0
     assert dec(0x01) == 2.0**-9
     assert _isnegzero(dec(0x80))
@@ -43,7 +43,7 @@ def test_spot_check_ocp_e4m3():
 def test_spot_check_p3109_p3():
     fi = format_info_p3109(3)
     dec = lambda ival: decode_float(fi, ival).fval
-    fclass = lambda ival: decode_float(fi, ival).fclass
+
     assert dec(0x01) == 2.0**-17
     assert dec(0x40) == 1.0
     assert np.isnan(dec(0x80))
@@ -54,7 +54,7 @@ def test_spot_check_p3109_p3():
 def test_spot_check_p3109_p1():
     fi = format_info_p3109(1)
     dec = lambda ival: decode_float(fi, ival).fval
-    fclass = lambda ival: decode_float(fi, ival).fclass
+
     assert dec(0x01) == 2.0**-62
     assert dec(0x40) == 2.0
     assert np.isnan(dec(0x80))
@@ -65,7 +65,7 @@ def test_spot_check_p3109_p1():
 def test_spot_check_binary16():
     fi = format_info_binary16
     dec = lambda ival: decode_float(fi, ival).fval
-    fclass = lambda ival: decode_float(fi, ival).fclass
+
     assert dec(0x3C00) == 1.0
     assert dec(0x3C01) == 1.0 + 2**-10
     assert dec(0x4000) == 2.0
@@ -79,7 +79,7 @@ def test_spot_check_binary16():
 def test_spot_check_bfloat16():
     fi = format_info_bfloat16
     dec = lambda ival: decode_float(fi, ival).fval
-    fclass = lambda ival: decode_float(fi, ival).fclass
+
     assert dec(0x3F80) == 1
     assert dec(0x4000) == 2
     assert dec(0x0001) == 2**-133
@@ -93,7 +93,7 @@ def test_spot_check_ocp_e2m3():
     # Test against Table 4 in "OCP Microscaling Formats (MX) v1.0 Spec"
     fi = format_info_ocp_e2m3
     dec = lambda ival: decode_float(fi, ival).fval
-    fclass = lambda ival: decode_float(fi, ival).fclass
+
     assert fi.max == 7.5
     assert fi.smallest_subnormal == 0.125
     assert fi.smallest_normal == 1.0
@@ -110,7 +110,7 @@ def test_spot_check_ocp_e3m2():
     # Test against Table 4 in "OCP Microscaling Formats (MX) v1.0 Spec"
     fi = format_info_ocp_e3m2
     dec = lambda ival: decode_float(fi, ival).fval
-    fclass = lambda ival: decode_float(fi, ival).fclass
+
     assert fi.max == 28.0
     assert fi.smallest_subnormal == 0.0625
     assert fi.smallest_normal == 0.25
@@ -127,7 +127,7 @@ def test_spot_check_ocp_e2m1():
     # Test against Table 5 in "OCP Microscaling Formats (MX) v1.0 Spec"
     fi = format_info_ocp_e2m1
     dec = lambda ival: decode_float(fi, ival).fval
-    fclass = lambda ival: decode_float(fi, ival).fclass
+
     assert fi.max == 6.0
     assert fi.smallest_subnormal == 0.5
     assert fi.smallest_normal == 1.0
@@ -169,16 +169,17 @@ def test_spot_check_ocp_int8():
     # Test against Table TODO in "OCP Microscaling Formats (MX) v1.0 Spec"
     fi = format_info_ocp_int8
     dec = lambda ival: decode_float(fi, ival).fval
-    fclass = lambda ival: decode_float(fi, ival).fclass
+
     assert fi.max == 1.0 + 63.0 / 64
     assert fi.smallest == 2.0**-6
     assert not fi.has_infs
-    assert fi.num_nans == 1
+    assert fi.num_nans == 0
 
     assert dec(0x00) == 0.0
     assert dec(0x01) == fi.smallest
     assert dec(0x7F) == fi.max
-    assert dec(0x81) == fi.min
+    assert dec(0x80) == -2.0
+    assert dec(0x80) == fi.min
     assert dec(0xFF) == -fi.smallest
 
 

--- a/test/test_decode.py
+++ b/test/test_decode.py
@@ -162,7 +162,8 @@ def test_specials(fi):
 def test_specials_decode(fi):
     dec = lambda v: decode_float(fi, v).fval
 
-    assert dec(fi.code_of_zero) == 0
+    if fi.has_zero:
+        assert dec(fi.code_of_zero) == 0
 
     if fi.num_nans > 0:
         assert np.isnan(dec(fi.code_of_nan))

--- a/test/test_decode.py
+++ b/test/test_decode.py
@@ -18,7 +18,7 @@ def test_spot_check_ocp_e5m2():
     fclass = lambda ival: decode_float(fi, ival).fclass
     assert dec(0x01) == 2.0**-16
     assert dec(0x40) == 2.0
-    assert dec(0x80) == 0.0 and np.signbit(dec(0x80))
+    assert _isnegzero(dec(0x80))
     assert dec(0x7B) == 57344.0
     assert dec(0x7C) == np.inf
     assert np.floor(np.log2(dec(0x7B))) == fi.emax
@@ -34,7 +34,7 @@ def test_spot_check_ocp_e4m3():
     fclass = lambda ival: decode_float(fi, ival).fclass
     assert dec(0x40) == 2.0
     assert dec(0x01) == 2.0**-9
-    assert dec(0x80) == 0.0 and np.signbit(dec(0x80))
+    assert _isnegzero(dec(0x80))
     assert np.isnan(dec(0x7F))
     assert dec(0x7E) == 448.0
     assert np.floor(np.log2(dec(0x7E))) == fi.emax
@@ -135,6 +135,19 @@ def test_spot_check_ocp_e2m1():
     assert dec(0b0110) == 4.0
     assert dec(0b0111) == 6.0
     assert _isnegzero(dec(0b1000))
+
+
+def test_spot_check_ocp_e8m0():
+    fi = format_info_ocp_e8m0
+    dec = lambda ival: decode_float(fi, ival).fval
+    fclass = lambda ival: decode_float(fi, ival).fclass
+    assert dec(0x00) == 2.0**-127
+    assert dec(0x01) == 2.0**-126
+    assert dec(0x7F) == 1.0
+    assert np.isnan(dec(0xFF))
+    assert fclass(0x80) == FloatClass.NORMAL
+    assert fclass(0x00) == FloatClass.NORMAL
+    assert fi.max == 2.0**127
 
 
 @pytest.mark.parametrize("fi", p3109_formats, ids=str)

--- a/test/test_decode.py
+++ b/test/test_decode.py
@@ -235,3 +235,14 @@ def test_consistent_decodes_all_values(fmt, npfmt, int_dtype):
 def test_except(v):
     with pytest.raises(ValueError):
         decode_float(format_info_binary16, v)
+
+
+@pytest.mark.parametrize("fi", [fi for fi in all_formats if fi.bits <= 8], ids=str)
+def test_dense(fi: FormatInfo):
+    dec = lambda v: decode_float(fi, v).fval
+
+    vals = np.array([dec(i) for i in range(0, 2**fi.bits)])
+
+    assert np.min(vals[np.isfinite(vals)]) == fi.min
+    assert np.max(vals[np.isfinite(vals)]) == fi.max
+    assert np.min(vals[np.isfinite(vals) & (vals > 0)]) == fi.smallest

--- a/test/test_encode.py
+++ b/test/test_encode.py
@@ -22,8 +22,8 @@ def test_encode(fi):
     for i in range(0, 2**fi.bits, step):
         fv = decode_float(fi, i)
         ival = encode_float(fi, fv.fval)
-        fv2 = decode_float(fi, ival)
         assert (i == ival) or np.isnan(fv.fval)
+        fv2 = decode_float(fi, ival)
         np.testing.assert_equal(fv2.fval, fv.fval)
 
 

--- a/test/test_encode.py
+++ b/test/test_encode.py
@@ -37,8 +37,9 @@ def test_encode_edges(fi):
         else fi.code_of_nan if fi.num_nans > 0 else fi.code_of_max
     )
 
-    assert encode_float(fi, fi.min * 1.25) == (
-        fi.code_of_neginf
-        if fi.has_infs
-        else fi.code_of_nan if fi.num_nans > 0 else fi.code_of_min
-    )
+    if fi.is_signed:
+        assert encode_float(fi, fi.min * 1.25) == (
+            fi.code_of_neginf
+            if fi.has_infs
+            else fi.code_of_nan if fi.num_nans > 0 else fi.code_of_min
+        )

--- a/test/test_round.py
+++ b/test/test_round.py
@@ -184,8 +184,6 @@ def test_round_ints(fi, mldtype):
 
 @pytest.mark.parametrize("fi", all_formats, ids=str)
 def test_round_roundtrip(fi):
-    dec = lambda v: decode_float(fi, v).fval
-
     if fi.bits <= 8:
         step = 1
     elif fi.bits <= 16:

--- a/test/test_round.py
+++ b/test/test_round.py
@@ -179,3 +179,20 @@ def test_round_ints(fi, mldtype):
 
         mlval = _mlround(v, mldtype)
         np.testing.assert_equal(val, mlval)
+
+
+@pytest.mark.parametrize("fi", all_formats, ids=str)
+def test_round_roundtrip(fi):
+    dec = lambda v: decode_float(fi, v).fval
+
+    if fi.bits <= 8:
+        step = 1
+    elif fi.bits <= 16:
+        step = 13
+    elif fi.bits <= 32:
+        step = 73013
+
+    for i in range(0, 2**fi.bits, step):
+        fv = decode_float(fi, i)
+        fval2 = round_float(fi, fv.fval)
+        np.testing.assert_equal(fval2, fv.fval)

--- a/test/test_round.py
+++ b/test/test_round.py
@@ -159,13 +159,14 @@ def test_ml_dtype_compatible(fi, mldtype):
     Test that rounding is compatible with ml_dtypes, assuming IEEE-like rounding
     """
     for i in range(255):
+        # For each float v, check values at various interpolations
+        # between v and nextUp(v)
         v0 = decode_float(fi, i + 0).fval
         v1 = decode_float(fi, i + 1).fval
 
-        for alpha in np.arange(0, 1.3, 0.3):
+        for alpha in (0, 0.3, 0.5, 0.6, 0.9, 1.25):
             v = _linterp(v0, v1, alpha)
             if np.isfinite(v):
-                print(i)
                 val = round_float(fi, v, RoundMode.TiesToEven)
 
                 mlval = _mlround(v, mldtype)


### PR DESCRIPTION
Add block formats (e.g. OCP MX)

Add OCP E8M0 type.  This is an unsigned format, so we add `is_signed` to `FormatInfo`.

Add OCP INT8 type.  This represents the significand as twos-complement, so we add `is_twos_complement` to `FormatInfo`.

Docs preview at https://gfloat--8.org.readthedocs.build/en/8/
