### PR TITLE
Simplify round, fix directed rounding

### DIFF
--- a/src/gfloat/round.py
+++ b/src/gfloat/round.py
@@ -94,8 +94,8 @@ def round_float(
             isignificand = math.floor(fsignificand)
             code_is_odd = isignificand != 0 and _isodd(expval + bias)
             if (
-                (rnd == RoundMode.TowardPositive and not sign)
-                or (rnd == RoundMode.TowardNegative and sign)
+                (rnd == RoundMode.TowardPositive and not sign and delta > 0)
+                or (rnd == RoundMode.TowardNegative and sign and delta > 0)
                 or (rnd == RoundMode.TiesToAway and delta >= 0.5)
                 or (rnd == RoundMode.TiesToEven and delta > 0.5)
                 or (rnd == RoundMode.TiesToEven and delta == 0.5 and code_is_odd)

--- a/src/gfloat/round.py
+++ b/src/gfloat/round.py
@@ -40,7 +40,6 @@ def round_float(
     # Constants
     p = fi.precision
     bias = fi.expBias
-    t = p - 1
 
     if np.isnan(v):
         if fi.num_nans == 0:

--- a/src/gfloat/round.py
+++ b/src/gfloat/round.py
@@ -80,8 +80,8 @@ def round_float(
         isignificand = math.floor(fsignificand)
         delta = fsignificand - isignificand
         if (
-            (rnd == RoundMode.TowardPositive and not sign)
-            or (rnd == RoundMode.TowardNegative and sign)
+            (rnd == RoundMode.TowardPositive and not sign and delta > 0)
+            or (rnd == RoundMode.TowardNegative and sign and delta > 0)
             or (rnd == RoundMode.TiesToAway and delta >= 0.5)
             or (rnd == RoundMode.TiesToEven and delta > 0.5)
             or (rnd == RoundMode.TiesToEven and delta == 0.5 and _isodd(isignificand))
@@ -108,6 +108,7 @@ def round_float(
                 else:
                     assert isignificand == 1
                     expval += 1
+        ## End special case for Precision=1.
 
         result = isignificand * (2.0**expval)
 

--- a/src/gfloat/round.py
+++ b/src/gfloat/round.py
@@ -56,10 +56,8 @@ def round_float(
     if np.isinf(vpos):
         result = np.inf
 
-    elif fi.has_subnormals and vpos < fi.smallest_subnormal / 2:
-        # Test against smallest_subnormal to avoid subnormals in frexp below
-        # Note that this restricts us to types narrower than float64
-        result = 0.0
+    elif vpos == 0:
+        result = 0
 
     else:
         # Extract exponent
@@ -119,9 +117,15 @@ def round_float(
             return 0.0
 
     # Overflow
-    if result > (-fi.min if sign else fi.max):
-        if sat:
-            result = fi.max
+    amax = -fi.min if sign else fi.max
+    if result > amax:
+        if (
+            sat
+            or (rnd == RoundMode.TowardNegative and not sign and np.isfinite(v))
+            or (rnd == RoundMode.TowardPositive and sign and np.isfinite(v))
+            or (rnd == RoundMode.TowardZero and np.isfinite(v))
+        ):
+            result = amax
         else:
             if fi.has_infs:
                 result = np.inf

--- a/src/gfloat/round.py
+++ b/src/gfloat/round.py
@@ -73,34 +73,40 @@ def round_float(
 
         fsignificand = vpos * 2.0**-expval
 
-        # Round.
+        # Round
         isignificand = math.floor(fsignificand)
         delta = fsignificand - isignificand
-
-        # Is the integer codepoint odd or even?
-        if rnd == RoundMode.TiesToEven:
-            code_is_odd = _isodd(isignificand)
-            if fi.precision == 1:  # When precision == 1, also check exponent.
-                code_is_odd = isignificand != 0 and _isodd(expval + bias)
-
-        # Rounded value will be either isignificand or isignificand+1.
         if (
-            (
-                rnd == RoundMode.TiesToEven
-                and (delta > 0.5 or delta == 0.5 and code_is_odd)
-            )
-            or (rnd == RoundMode.TiesToAway and delta >= 0.5)
-            or (rnd == RoundMode.TowardPositive and not sign and delta > 0)
+            (rnd == RoundMode.TowardPositive and not sign and delta > 0)
             or (rnd == RoundMode.TowardNegative and sign and delta > 0)
+            or (rnd == RoundMode.TiesToAway and delta >= 0.5)
+            or (rnd == RoundMode.TiesToEven and delta > 0.5)
+            or (rnd == RoundMode.TiesToEven and delta == 0.5 and _isodd(isignificand))
         ):
             isignificand += 1
-            if fi.precision == 1 and isignificand == 2:
-                # Special case for p = 1: carry overflowed significand to exponent.
-                # (Not needed for p>1 as we are reconstructing, not encoding)
-                isignificand = 1
-                expval += 1
 
-        # Reconstruct from integer significand and exponent
+        ## Special case for Precision=1, all-log format with zero.
+        if fi.precision == 1:
+            # The logic is simply duplicated for clarity of reading.
+            isignificand = math.floor(fsignificand)
+            code_is_odd = isignificand != 0 and _isodd(expval + bias)
+            if (
+                (rnd == RoundMode.TowardPositive and not sign and delta > 0)
+                or (rnd == RoundMode.TowardNegative and sign and delta > 0)
+                or (rnd == RoundMode.TiesToAway and delta >= 0.5)
+                or (rnd == RoundMode.TiesToEven and delta > 0.5)
+                or (rnd == RoundMode.TiesToEven and delta == 0.5 and code_is_odd)
+            ):
+                # Go to nextUp.
+                # Increment isignificand if zero,
+                # else increment exponent
+                if isignificand == 0:
+                    isignificand = 1
+                else:
+                    assert isignificand == 1
+                    expval += 1
+        ## End special case for Precision=1.
+
         result = isignificand * (2.0**expval)
 
     if result == 0:

--- a/src/gfloat/round.py
+++ b/src/gfloat/round.py
@@ -63,11 +63,10 @@ def round_float(
 
     else:
         # Extract significand (mantissa) and exponent
-        fsignificand, expval = np.frexp(vpos)
-        assert fsignificand >= 0.5 and fsignificand < 1.0
-        # Bring significand into range [1.0, 2.0)
-        fsignificand *= 2
-        expval -= 1
+        expval = int(np.floor(np.log2(vpos)))
+        fsignificand = vpos * 2.0**-expval
+
+        assert fsignificand >= 1.0 and fsignificand < 2.0
 
         # Effective precision, accounting for right shift for subnormal values
         biased_exp = expval + bias

--- a/src/gfloat/types.py
+++ b/src/gfloat/types.py
@@ -146,7 +146,7 @@ class FormatInfo:
     @property
     def eps(self) -> float:
         """
-        The difference between 1.0 and the next smallest representable float
+        The difference between 1.0 and the smallest representable float
         larger than 1.0. For example, for 64-bit binary floats in the IEEE-754
         standard, ``eps = 2**-52``, approximately 2.22e-16.
         """
@@ -156,7 +156,7 @@ class FormatInfo:
     @property
     def epsneg(self) -> float:
         """
-        The difference between 1.0 and the next smallest representable float
+        The difference between 1.0 and the largest representable float
         less than 1.0. For example, for 64-bit binary floats in the IEEE-754
         standard, ``epsneg = 2**-53``, approximately 1.11e-16.
         """

--- a/test/test_round.py
+++ b/test/test_round.py
@@ -10,13 +10,6 @@ from gfloat import RoundMode, decode_float, round_float
 from gfloat.formats import *
 
 
-def _mlround(v: float, dty: Type) -> float:
-    """
-    Round `v` using ml_dtypes library
-    """
-    return np.array([v]).astype(dty).astype(float).item()
-
-
 def test_round_p3109() -> None:
     fi = format_info_p3109(4)
     assert round_float(fi, 0.0068359375) == 0.0068359375
@@ -154,10 +147,17 @@ def _linterp(a: float, b: float, t: float) -> float:
     return a * (1 - t) + b * t
 
 
+def _mlround(v: float, dty: Type) -> float:
+    """
+    Round `v` using ml_dtypes library
+    """
+    return np.array([v]).astype(dty).astype(float).item()
+
+
 @pytest.mark.parametrize("fi,mldtype", test_formats)
 def test_ml_dtype_compatible(fi: FormatInfo, mldtype: Type) -> None:
     """
-    Test that rounding is compatible with ml_dtypes, assuming IEEE-like rounding
+    Test that rounding is compatible with ml_dtypes
     """
     for i in range(255):
         # For each float v, check values at various interpolations

--- a/test/test_round.py
+++ b/test/test_round.py
@@ -27,9 +27,6 @@ def test_round_p3109() -> None:
     assert round_float(fi, 232.0, RoundMode.TowardNegative) == 224.0
     assert round_float(fi, 232.0, RoundMode.TowardPositive) == np.inf
 
-    assert round_float(fi, -1.0, RoundMode.TowardNegative) == -1.0
-    assert round_float(fi, 1.0, RoundMode.TowardPositive) == 1.0
-
     assert round_float(fi, -232.0) == -224.0
     assert round_float(fi, -232.0, RoundMode.TiesToAway) == -np.inf
     assert round_float(fi, -232.0, RoundMode.TowardZero) == -224.0
@@ -50,8 +47,10 @@ p4min = 2**-10  # smallest subnormal in p4
             (
                 (p4min, p4min),
                 (p4min / 4, 0),
+                (p4min / 2, 0),
                 (-p4min, -p4min),
                 (-p4min / 4, 0.0),
+                (-p4min / 2, 0.0),
                 (64.0, 64.0),
                 (63.0, 60.0),
                 (62.0, 60.0),
@@ -65,8 +64,10 @@ p4min = 2**-10  # smallest subnormal in p4
             (
                 (p4min, p4min),
                 (p4min / 4, p4min),
+                (p4min / 2, p4min),
                 (-p4min, -p4min),
                 (-p4min / 4, 0.0),
+                (-p4min / 2, 0.0),
                 (64.0, 64.0),
                 (63.0, 64.0),
                 (62.0, 64.0),
@@ -80,8 +81,10 @@ p4min = 2**-10  # smallest subnormal in p4
             (
                 (p4min, p4min),
                 (p4min / 4, 0),
+                (p4min / 2, 0),
                 (-p4min, -p4min),
                 (-p4min / 4, -p4min),
+                (-p4min / 2, -p4min),
                 (64.0, 64.0),
                 (63.0, 60.0),
                 (62.0, 60.0),

--- a/test/test_round.py
+++ b/test/test_round.py
@@ -46,8 +46,8 @@ p4min = 2**-10  # smallest subnormal in p4
             RoundMode.TowardZero,
             (
                 (p4min, p4min),
-                (p4min / 4, 0),
-                (p4min / 2, 0),
+                (p4min / 4, 0.0),
+                (p4min / 2, 0.0),
                 (-p4min, -p4min),
                 (-p4min / 4, 0.0),
                 (-p4min / 2, 0.0),
@@ -80,8 +80,8 @@ p4min = 2**-10  # smallest subnormal in p4
             RoundMode.TowardNegative,
             (
                 (p4min, p4min),
-                (p4min / 4, 0),
-                (p4min / 2, 0),
+                (p4min / 4, 0.0),
+                (p4min / 2, 0.0),
                 (-p4min, -p4min),
                 (-p4min / 4, -p4min),
                 (-p4min / 2, -p4min),
@@ -97,11 +97,11 @@ p4min = 2**-10  # smallest subnormal in p4
             RoundMode.TiesToEven,
             (
                 (p4min, p4min),
-                (p4min / 4, 0),
-                (p4min / 2, 0),
+                (p4min / 4, 0.0),
+                (p4min / 2, 0.0),
                 (-p4min, -p4min),
-                (-p4min / 4, 0),
-                (-p4min / 2, 0),
+                (-p4min / 4, 0.0),
+                (-p4min / 2, 0.0),
                 (64.0, 64.0),
                 (63.0, 64.0),
                 (62.0, 64.0),
@@ -117,10 +117,10 @@ p4min = 2**-10  # smallest subnormal in p4
             RoundMode.TiesToAway,
             (
                 (p4min, p4min),
-                (p4min / 4, 0),
+                (p4min / 4, 0.0),
                 (p4min / 2, p4min),
                 (-p4min, -p4min),
-                (-p4min / 4, 0),
+                (-p4min / 4, 0.0),
                 (-p4min / 2, -p4min),
                 (64.0, 64.0),
                 (63.0, 64.0),
@@ -282,9 +282,7 @@ p4maxhalfup = (p4max + p4maxup) / 2
             ),
         ),
     ),
-    ids=lambda x: (
-        f"{str(x[0])}-{'Sat' if x[1] else 'Inf'}" if len(x) == 2 else f"{len(x)}"
-    ),
+    ids=lambda x: f"{str(x[0])}-{'Sat' if x[1] else 'Inf'}" if len(x) == 2 else None,
 )
 def test_round_p3109_sat(modesat: tuple[RoundMode, bool], vals: list) -> None:
     fi = format_info_p3109(4)

--- a/test/test_round.py
+++ b/test/test_round.py
@@ -138,9 +138,9 @@ p4min = 2**-10  # smallest subnormal in p4
 def test_round_p3109b(mode, vals) -> None:
     fi = format_info_p3109(4)
 
-    for val, expected in vals:
-        sat = True
-        assert round_float(fi, val, mode, sat) == expected
+    for sat in (True, False):
+        for val, expected in vals:
+            assert round_float(fi, val, mode, sat) == expected
 
 
 p4max = 224.0

--- a/test/test_round.py
+++ b/test/test_round.py
@@ -39,6 +39,257 @@ def test_round_p3109() -> None:
     assert round_float(fi, 232.1) == np.inf
 
 
+p4min = 2**-10  # smallest subnormal in p4
+
+
+@pytest.mark.parametrize(
+    "mode, vals",
+    (
+        (
+            RoundMode.TowardZero,
+            (
+                (p4min, p4min),
+                (p4min / 4, 0),
+                (-p4min, -p4min),
+                (-p4min / 4, 0.0),
+                (64.0, 64.0),
+                (63.0, 60.0),
+                (62.0, 60.0),
+                (-64.0, -64.0),
+                (-63.0, -60.0),
+                (-62.0, -60.0),
+            ),
+        ),
+        (
+            RoundMode.TowardPositive,
+            (
+                (p4min, p4min),
+                (p4min / 4, p4min),
+                (-p4min, -p4min),
+                (-p4min / 4, 0.0),
+                (64.0, 64.0),
+                (63.0, 64.0),
+                (62.0, 64.0),
+                (-64.0, -64.0),
+                (-63.0, -60.0),
+                (-62.0, -60.0),
+            ),
+        ),
+        (
+            RoundMode.TowardNegative,
+            (
+                (p4min, p4min),
+                (p4min / 4, 0),
+                (-p4min, -p4min),
+                (-p4min / 4, -p4min),
+                (64.0, 64.0),
+                (63.0, 60.0),
+                (62.0, 60.0),
+                (-64.0, -64.0),
+                (-63.0, -64.0),
+                (-62.0, -64.0),
+            ),
+        ),
+        (
+            RoundMode.TiesToEven,
+            (
+                (p4min, p4min),
+                (p4min / 4, 0),
+                (p4min / 2, 0),
+                (-p4min, -p4min),
+                (-p4min / 4, 0),
+                (-p4min / 2, 0),
+                (64.0, 64.0),
+                (63.0, 64.0),
+                (62.0, 64.0),
+                (61.0, 60.0),
+                (-64.0, -64.0),
+                (-63.0, -64.0),
+                (-62.0, -64.0),
+                (-61.0, -60.0),
+                (-58.0, -56.0),
+            ),
+        ),
+        (
+            RoundMode.TiesToAway,
+            (
+                (p4min, p4min),
+                (p4min / 4, 0),
+                (p4min / 2, p4min),
+                (-p4min, -p4min),
+                (-p4min / 4, 0),
+                (-p4min / 2, -p4min),
+                (64.0, 64.0),
+                (63.0, 64.0),
+                (62.0, 64.0),
+                (61.0, 60.0),
+                (-64.0, -64.0),
+                (-63.0, -64.0),
+                (-62.0, -64.0),
+                (-61.0, -60.0),
+                (-58.0, -60.0),
+            ),
+        ),
+    ),
+)
+def test_round_p3109b(mode, vals) -> None:
+    fi = format_info_p3109(4)
+
+    for val, expected in vals:
+        sat = True
+        assert round_float(fi, val, mode, sat) == expected
+
+
+p4max = 224.0
+p4maxup = 240.0
+p4maxhalfup = (p4max + p4maxup) / 2
+
+
+@pytest.mark.parametrize(
+    "modesat, vals",
+    (
+        (
+            (RoundMode.TowardZero, True),
+            (
+                (p4max, p4max),
+                (p4maxhalfup, p4max),
+                (p4maxup, p4max),
+                (np.inf, p4max),
+                (-p4max, -p4max),
+                (-p4maxhalfup, -p4max),
+                (-p4maxup, -p4max),
+                (-np.inf, -p4max),
+            ),
+        ),
+        (
+            (RoundMode.TowardZero, False),
+            (
+                (p4max, p4max),
+                (p4maxhalfup, p4max),
+                (p4maxup, p4max),
+                (np.inf, np.inf),
+                (-p4max, -p4max),
+                (-p4maxhalfup, -p4max),
+                (-p4maxup, -p4max),
+                (-np.inf, -np.inf),
+            ),
+        ),
+        (
+            (RoundMode.TowardPositive, True),
+            (
+                (p4max, p4max),
+                (p4maxhalfup, p4max),
+                (p4maxup, p4max),
+                (np.inf, p4max),
+                (-p4max, -p4max),
+                (-p4maxhalfup, -p4max),
+                (-p4maxup, -p4max),
+                (-np.inf, -p4max),
+            ),
+        ),
+        (
+            (RoundMode.TowardPositive, False),
+            (
+                (p4max, p4max),
+                (p4maxhalfup, np.inf),
+                (p4maxup, np.inf),
+                (np.inf, np.inf),
+                (-p4max, -p4max),
+                (-p4maxhalfup, -p4max),
+                (-p4maxup, -p4max),
+                (-np.inf, -np.inf),
+            ),
+        ),
+        (
+            (RoundMode.TowardNegative, True),
+            (
+                (p4max, p4max),
+                (p4maxhalfup, p4max),
+                (p4maxup, p4max),
+                (np.inf, p4max),
+                (-p4max, -p4max),
+                (-p4maxhalfup, -p4max),
+                (-p4maxup, -p4max),
+                (-np.inf, -p4max),
+            ),
+        ),
+        (
+            (RoundMode.TowardNegative, False),
+            (
+                (p4max, p4max),
+                (p4maxhalfup, p4max),
+                (p4maxup, p4max),
+                (np.inf, np.inf),
+                (-p4max, -p4max),
+                (-p4maxhalfup, -np.inf),
+                (-p4maxup, -np.inf),
+                (-np.inf, -np.inf),
+            ),
+        ),
+        (
+            (RoundMode.TiesToEven, True),
+            (
+                (p4max, p4max),
+                (p4maxhalfup, p4max),
+                (p4maxup, p4max),
+                (np.inf, p4max),
+                (-p4max, -p4max),
+                (-p4maxhalfup, -p4max),
+                (-p4maxup, -p4max),
+                (-np.inf, -p4max),
+            ),
+        ),
+        (
+            (RoundMode.TiesToEven, False),
+            (
+                (p4max, p4max),
+                (p4maxhalfup, p4max),
+                (p4maxup, np.inf),
+                (np.inf, np.inf),
+                (-p4max, -p4max),
+                (-p4maxhalfup, -p4max),
+                (-p4maxup, -np.inf),
+                (-np.inf, -np.inf),
+            ),
+        ),
+        (
+            (RoundMode.TiesToAway, True),
+            (
+                (p4max, p4max),
+                (p4maxhalfup, p4max),
+                (p4maxup, p4max),
+                (np.inf, p4max),
+                (-p4max, -p4max),
+                (-p4maxhalfup, -p4max),
+                (-p4maxup, -p4max),
+                (-np.inf, -p4max),
+            ),
+        ),
+        (
+            (RoundMode.TiesToAway, False),
+            (
+                (p4max, p4max),
+                (p4maxhalfup, np.inf),
+                (p4maxup, np.inf),
+                (np.inf, np.inf),
+                (-p4max, -p4max),
+                (-p4maxhalfup, -np.inf),
+                (-p4maxup, -np.inf),
+                (-np.inf, -np.inf),
+            ),
+        ),
+    ),
+    ids=lambda x: (
+        f"{str(x[0])}-{'Sat' if x[1] else 'Inf'}" if len(x) == 2 else f"{len(x)}"
+    ),
+)
+def test_round_p3109_sat(modesat, vals) -> None:
+    fi = format_info_p3109(4)
+
+    for val, expected in vals:
+        assert round_float(fi, val, *modesat) == expected
+
+
 def test_round_e5m2() -> None:
     fi = format_info_ocp_e5m2
 

--- a/test/test_round.py
+++ b/test/test_round.py
@@ -27,6 +27,9 @@ def test_round_p3109() -> None:
     assert round_float(fi, 232.0, RoundMode.TowardNegative) == 224.0
     assert round_float(fi, 232.0, RoundMode.TowardPositive) == np.inf
 
+    assert round_float(fi, -1.0, RoundMode.TowardNegative) == -1.0
+    assert round_float(fi, 1.0, RoundMode.TowardPositive) == 1.0
+
     assert round_float(fi, -232.0) == -224.0
     assert round_float(fi, -232.0, RoundMode.TiesToAway) == -np.inf
     assert round_float(fi, -232.0, RoundMode.TowardZero) == -224.0

--- a/test/test_round.py
+++ b/test/test_round.py
@@ -135,7 +135,7 @@ p4min = 2**-10  # smallest subnormal in p4
         ),
     ),
 )
-def test_round_p3109b(mode, vals) -> None:
+def test_round_p3109b(mode: RoundMode, vals: list) -> None:
     fi = format_info_p3109(4)
 
     for sat in (True, False):
@@ -286,7 +286,7 @@ p4maxhalfup = (p4max + p4maxup) / 2
         f"{str(x[0])}-{'Sat' if x[1] else 'Inf'}" if len(x) == 2 else f"{len(x)}"
     ),
 )
-def test_round_p3109_sat(modesat, vals) -> None:
+def test_round_p3109_sat(modesat: tuple[RoundMode, bool], vals: list) -> None:
     fi = format_info_p3109(4)
 
     for val, expected in vals:


### PR DESCRIPTION
Simplifying definition of "round", plus bugfixes to handling of directed rounding modes.

This definition further emphasizes that gfloat is biased toward readability rather than speed - e.g. using `log2` rather than `frexp`.