### PR TITLE
Use python ints throughout, adding float64 to test

### DIFF
--- a/src/gfloat/formats.py
+++ b/src/gfloat/formats.py
@@ -3,6 +3,20 @@
 from .block import BlockFormatInfo
 from .types import FormatInfo
 
+#: FormatInfo for IEEE-754 Binary64 format
+format_info_binary64 = FormatInfo(
+    name="binary64",
+    k=64,
+    precision=53,
+    emax=1023,
+    has_nz=True,
+    has_infs=True,
+    num_high_nans=2**52 - 1,
+    has_subnormals=True,
+    is_signed=True,
+    is_twos_complement=False,
+)
+
 #: FormatInfo for IEEE-754 Binary32 format
 format_info_binary32 = FormatInfo(
     name="binary32",
@@ -204,6 +218,7 @@ all_formats = [
     *_fp8_formats,
     *_fp16_formats,
     format_info_binary32,
+    format_info_binary64,
 ]
 
 # ------

--- a/src/gfloat/round.py
+++ b/src/gfloat/round.py
@@ -62,8 +62,6 @@ def round_float(
         # Extract exponent
         expval = int(np.floor(np.log2(vpos)))
 
-        assert expval > -1024 + p  # not yet tested for float64 near-subnormals
-
         # Effective precision, accounting for right shift for subnormal values
         if fi.has_subnormals:
             expval = max(expval, 1 - bias)
@@ -71,7 +69,8 @@ def round_float(
         # Lift to "integer * 2^e"
         expval = expval - p + 1
 
-        fsignificand = vpos * 2.0**-expval
+        # use ldexp instead of vpos*2**-expval to avoid overflow
+        fsignificand = math.ldexp(vpos, -expval)
 
         # Round
         isignificand = math.floor(fsignificand)

--- a/src/gfloat/round.py
+++ b/src/gfloat/round.py
@@ -191,8 +191,9 @@ def encode_float(fi: FormatInfo, v: float) -> int:
         isig = 0
         biased_exp = 0
     else:
-        assert fi.bits < 64  # TODO: check implementation if fi is binary64
         sig, exp = np.frexp(vpos)
+        exp = int(exp)  # All calculations in Python ints
+
         # sig in range [0.5, 1)
         sig *= 2
         exp -= 1
@@ -226,6 +227,6 @@ def encode_float(fi: FormatInfo, v: float) -> int:
         isig = (1 << t) - isig
 
     # Pack values into a single integer
-    code = (sign << (k - 1)) | (biased_exp << t) | (isig << 0)
+    code = (int(sign) << (k - 1)) | (biased_exp << t) | (isig << 0)
 
     return code

--- a/test/test_encode.py
+++ b/test/test_encode.py
@@ -18,6 +18,8 @@ def test_encode(fi: FormatInfo) -> None:
         step = 13
     elif fi.bits <= 32:
         step = 73013
+    elif fi.bits <= 64:
+        step = (73013 << 32) + 39
 
     for i in range(0, 2**fi.bits, step):
         fv = decode_float(fi, i)

--- a/test/test_round.py
+++ b/test/test_round.py
@@ -446,6 +446,8 @@ def test_round_roundtrip(fi: FormatInfo) -> None:
         step = 13
     elif fi.bits <= 32:
         step = 73013
+    elif fi.bits <= 64:
+        step = (73013 << 32) + 39
 
     for i in range(0, 2**fi.bits, step):
         fv = decode_float(fi, i)


### PR DESCRIPTION
Add float64 to formats, and update integer computations to handle them.

Fixes #25 
