### PR TITLE
Fix torch/numpy versions for MX in tests

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,7 @@
 # PyPI doesn't like direct dependencies - see https://github.com/microsoft/microxcaling/issues/22
 
 mx @ git+https://github.com/microsoft/microxcaling
+numpy<2.0.0 # microscaling needs pytorch 2.1, which needs to be less than 2.0
+torch==2.1.0 --index-url https://download.pytorch.org/whl/cpu
+torchvision==0.16.0
+torchaudio==2.1.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,6 @@
 # PyPI doesn't like direct dependencies - see https://github.com/microsoft/microxcaling/issues/22
 
-mx @ git+https://github.com/microsoft/microxcaling
 numpy<2.0.0 # microscaling needs pytorch 2.1, which needs to be less than 2.0
 torch==2.1.0 --index-url https://download.pytorch.org/whl/cpu
-torchvision==0.16.0
-torchaudio==2.1.0
+
+mx @ git+https://github.com/microsoft/microxcaling

--- a/test/test_microxcaling.py
+++ b/test/test_microxcaling.py
@@ -7,8 +7,8 @@ from numpy.typing import NDArray
 
 import torch
 
-from mx.mx_ops import quantize_mx_op
 from mx.formats import ElemFormat
+from mx.mx_ops import quantize_mx_op
 
 
 from gfloat import (

--- a/test/test_microxcaling.py
+++ b/test/test_microxcaling.py
@@ -7,8 +7,8 @@ from numpy.typing import NDArray
 
 import torch
 
-from mx.formats import ElemFormat
 from mx.mx_ops import quantize_mx_op
+from mx.formats import ElemFormat
 
 
 from gfloat import (


### PR DESCRIPTION
Before:
```
FAILED test/test_microxcaling.py::test_mx[zeros-ElemFormat.fp4-ocp_e2m1-even-RoundMode.TiesToEven] - RuntimeError: Numpy is not available
```
Re https://github.com/pytorch/pytorch/issues/107302
