### PR TITLE
Avoid overflow/conversion errors in vectorized code.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,4 +41,4 @@ ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 addopts = "--nbval"
-testpaths = ["test", "doc"]
+testpaths = ["docs", "test"]

--- a/test/test_decode.py
+++ b/test/test_decode.py
@@ -260,6 +260,8 @@ def test_consistent_decodes_all_values(
     npivals = np.arange(
         np.iinfo(int_dtype).min, int(np.iinfo(int_dtype).max) + 1, dtype=int_dtype
     )
+
+    # Warning here when converting bfloat16 NaNs to float64
     npfvals = npivals.view(dtype=npfmt).astype(np.float64)
 
     # Scalar version

--- a/test/test_decode.py
+++ b/test/test_decode.py
@@ -261,8 +261,9 @@ def test_consistent_decodes_all_values(
         np.iinfo(int_dtype).min, int(np.iinfo(int_dtype).max) + 1, dtype=int_dtype
     )
 
-    # Warning here when converting bfloat16 NaNs to float64
-    npfvals = npivals.view(dtype=npfmt).astype(np.float64)
+    with np.errstate(invalid="ignore"):
+        # Warning here when converting bfloat16 NaNs to float64
+        npfvals = npivals.view(dtype=npfmt).astype(np.float64)
 
     # Scalar version
     for i, npfval in zip(npivals, npfvals):


### PR DESCRIPTION
Some vectorized code caused overflows/conversion errors.  These did not influence correctness, as they were in non-taken elememts of an `np.where`, but it appears better to remove them.  No speed implications within timing noise.
```
GFloat scalar                  :  7908.50 nsec (25 runs at size 10000)
GFloat vectorized, numpy arrays:    62.24 nsec (25 runs at size 1000000)
GFloat vectorized, JAX JIT     :     3.52 nsec (250 runs at size 1000000)
ML_dtypes                      :     3.43 nsec (500 runs at size 1000000)
```
