### PR TITLE
Simplify rounding for precision=1

### DIFF
--- a/src/gfloat/round.py
+++ b/src/gfloat/round.py
@@ -108,15 +108,10 @@ def round_float(
             should_round_away = delta > (0.5 + srbits) * 2.0**-srnumbits
 
         if should_round_away:
-            if fi.precision > 1:
-                isignificand += 1
-            else:
-                # Increment isignificand if zero, else increment exponent
-                if isignificand == 0:
-                    isignificand = 1
-                else:
-                    assert isignificand == 1
-                    expval += 1
+            # This may increase isignificand to 2**p,
+            # which would require special casing in encode,
+            # but not here, where we reconstruct a rounded value.
+            isignificand += 1
 
         # Reconstruct rounded result to float
         result = isignificand * (2.0**expval)

--- a/src/gfloat/round_ndarray.py
+++ b/src/gfloat/round_ndarray.py
@@ -81,16 +81,7 @@ def round_ndarray(
     else:
         round_up = np.zeros_like(delta, dtype=bool)
 
-    if fi.precision > 1:
-        isignificand = np.where(round_up, isignificand + 1, isignificand)
-    else:
-        # if isignificand == 0:
-        #     isignificand = 1
-        # else:
-        #     assert isignificand == 1
-        #     expval += 1
-        expval += round_up & (isignificand == 1)
-        isignificand = np.where(round_up, 1, isignificand)
+    isignificand = np.where(round_up, isignificand + 1, isignificand)
 
     result = np.where(finite_nonzero, np.ldexp(isignificand, expval), absv)
 


### PR DESCRIPTION
Rounding for precision = 1 had complex logic to increment the exponent if the significand increased to 2, however this was not needed, either for p=1, or indeed, for any precision - if the significand becomes 2**p, it simply reconstructs the first value in the next binade, which is always non-subnormal.