### PR TITLE
Use array-api for cross-framework compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ cython_debug/
 #.idea/
 .vscode/settings.json
 .vscode/launch.json
+
+# Local
+tmp/

--- a/docs/source/04-benchmark.ipynb
+++ b/docs/source/04-benchmark.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -34,24 +34,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "GFloat scalar                  :  6306.18 nsec (25 runs at size 10000)\n",
-      "GFloat vectorized, numpy arrays:    52.52 nsec (25 runs at size 1000000)\n",
-      "GFloat vectorized, JAX JIT     :     3.04 nsec (500 runs at size 1000000)\n",
-      "ML_dtypes                      :     2.69 nsec (500 runs at size 1000000)\n"
+      "GFloat scalar                  :  7510.22 nsec (25 runs at size 10000)\n",
+      "GFloat vectorized, numpy arrays:    43.82 nsec (25 runs at size 1000000)\n",
+      "GFloat vectorized, JAX JIT     :     2.69 nsec (500 runs at size 1000000)\n",
+      "ML_dtypes                      :     2.57 nsec (500 runs at size 1000000)\n"
      ]
     }
    ],
@@ -61,7 +54,7 @@
     "N = 1_000_000\n",
     "a = np.random.rand(N)\n",
     "\n",
-    "jax_round_jit = jax.jit(lambda x: gfloat.round_ndarray(format_info_ocp_e5m2, x, np=jnp))\n",
+    "jax_round_jit = jax.jit(lambda x: gfloat.round_ndarray(format_info_ocp_e5m2, x))\n",
     "ja = jnp.array(a)\n",
     "jax_round_jit(ja)  # Cache compilation\n",
     "\n",
@@ -108,7 +101,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },

--- a/src/gfloat/types.py
+++ b/src/gfloat/types.py
@@ -232,7 +232,7 @@ class FormatInfo:
                 return -self.max
             else:
                 assert not self.has_infs and self.num_high_nans == 0 and not self.has_nz
-                return -(2 ** (self.emax + 1))
+                return -(2.0 ** (self.emax + 1))
         elif self.has_zero:
             return 0.0
         else:

--- a/test/test_array_api.py
+++ b/test/test_array_api.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2024 Graphcore Ltd. All rights reserved.
+
+import array_api_strict as xp
+import numpy as np
+import pytest
+
+from gfloat import RoundMode, decode_float, decode_ndarray, round_float, round_ndarray
+from gfloat.formats import *
+
+xp.set_array_api_strict_flags(api_version="2024.12")
+
+# Hack until https://github.com/data-apis/array-api/issues/807
+_xp_where = xp.where
+xp.where = lambda a, t, f: _xp_where(a, xp.asarray(t), xp.asarray(f))
+_xp_maximum = xp.maximum
+xp.maximum = lambda a, b: _xp_maximum(xp.asarray(a), xp.asarray(b))
+
+
+@pytest.mark.parametrize("fi", all_formats)
+@pytest.mark.parametrize("rnd", RoundMode)
+@pytest.mark.parametrize("sat", [True, False])
+def test_array_api(fi, rnd, sat):
+    a = np.random.rand(23, 1, 34) - 0.5
+    a = xp.asarray(a)
+
+    srnumbits = 32
+    srbits = np.random.randint(0, 2**srnumbits, a.shape)
+    srbits = xp.asarray(srbits)
+
+    round_ndarray(fi, a, rnd, sat, srbits=srbits, srnumbits=srnumbits)

--- a/test/test_jax.py
+++ b/test/test_jax.py
@@ -22,11 +22,11 @@ def test_jax() -> None:
     a8 = a.astype(ml_dtypes.float8_e5m2).astype(jnp.float64)
 
     fi = format_info_ocp_e5m2
-    j8 = gfloat.round_ndarray(fi, jnp.array(a), np=jnp)  # type: ignore [arg-type]
+    j8 = gfloat.round_ndarray(fi, jnp.array(a))  # type: ignore [arg-type]
 
     np.testing.assert_equal(a8, j8)
 
-    jax_round_array = jax.jit(lambda x: gfloat.round_ndarray(fi, x, np=jnp))
+    jax_round_array = jax.jit(lambda x: gfloat.round_ndarray(fi, x))
     j8i = jax_round_array(a)
 
     np.testing.assert_equal(a8, j8i)


### PR DESCRIPTION
Previously, gfloat worked on JAX and Torch through some nasty [polyglottery](https://en.wikipedia.org/wiki/Polyglot_(computing)).

This PR uses [array-api-compat](https://github.com/data-apis/array-api-compat) to make that more formal.

Adds testing with [array-api-strict](https://github.com/data-apis/array-api-strict) - needs some shimming to get up to https://github.com/data-apis/array-api-strict/pull/100 -- that should be removed when that merges.

Adds torch benchmarks to 04-benchmarking - these probably need more work to become performant.